### PR TITLE
Support python3.8 - python3.12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools
-        pip install tox-gh-actions
+        python -m pip install tox-gh-actions
 
     - name: Run tox
       run: tox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox-env: ['py3', 'check-packaging', 'lint', 'coverage', 'docs']
+        tox-env: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
 
@@ -39,7 +39,7 @@ jobs:
         pip install tox-gh-actions
 
     - name: Run tox
-      run: tox -e ${{ matrix.tox-env }}
+      run: tox
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.0.1

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox-env: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
 
@@ -28,10 +28,10 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install graphviz
 
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |

--- a/entity_management/atlas.py
+++ b/entity_management/atlas.py
@@ -2,7 +2,6 @@
 
 """Atlas related entities."""
 
-from typing import List
 
 from entity_management.base import BrainLocation, Derivation, Identifiable, Subject, attributes
 from entity_management.core import Contribution, DataDownload, Entity
@@ -112,7 +111,7 @@ class HemisphereAnnotationDataLayer(Entity):
 
 @attributes(
     {
-        "distribution": AttrOf(List[DataDownload]),
+        "distribution": AttrOf(list[DataDownload]),
     }
 )
 class ParcellationOntology(Entity):
@@ -177,9 +176,9 @@ class AtlasRelease(Entity):
 @attributes(
     {
         "atlasRelease": AttrOf(AtlasRelease, default=None),
-        "about": AttrOf(List[str], default=None),
+        "about": AttrOf(list[str], default=None),
         "brainLocation": AttrOf(BrainLocation, default=None),
-        "contribution": AttrOf(List[Contribution], default=None),
+        "contribution": AttrOf(list[Contribution], default=None),
         "derivation": AttrOf(Derivation, default=None),
         "distribution": AttrOf(DataDownload),
         "subject": AttrOf(Subject, default=None),
@@ -191,10 +190,10 @@ class CellCompositionSummary(Entity):
 
 @attributes(
     {
-        "about": AttrOf(List[str], default=None),
+        "about": AttrOf(list[str], default=None),
         "atlasRelease": AttrOf(AtlasRelease, default=None),
         "brainLocation": AttrOf(BrainLocation, default=None),
-        "contribution": AttrOf(List[Contribution], default=None),
+        "contribution": AttrOf(list[Contribution], default=None),
         "derivation": AttrOf(Derivation, default=None),
         "distribution": AttrOf(DataDownload),
         "subject": AttrOf(Subject, default=None),
@@ -206,13 +205,13 @@ class CellCompositionVolume(Entity):
 
 @attributes(
     {
-        "about": AttrOf(List[str], default=None),
+        "about": AttrOf(list[str], default=None),
         "atlasRelease": AttrOf(AtlasRelease),
         "atlasSpatialReferenceSystem": AttrOf(AtlasSpatialReferenceSystem, default=None),
         "brainLocation": AttrOf(BrainLocation, default=None),
         "cellCompositionSummary": AttrOf(CellCompositionSummary),
         "cellCompositionVolume": AttrOf(CellCompositionVolume),
-        "contribution": AttrOf(List[Contribution], default=None),
+        "contribution": AttrOf(list[Contribution], default=None),
     }
 )
 class CellComposition(Entity):

--- a/entity_management/atlas.py
+++ b/entity_management/atlas.py
@@ -2,6 +2,7 @@
 
 """Atlas related entities."""
 
+from typing import List
 
 from entity_management.base import BrainLocation, Derivation, Identifiable, Subject, attributes
 from entity_management.core import Contribution, DataDownload, Entity
@@ -111,7 +112,7 @@ class HemisphereAnnotationDataLayer(Entity):
 
 @attributes(
     {
-        "distribution": AttrOf(list[DataDownload]),
+        "distribution": AttrOf(List[DataDownload]),
     }
 )
 class ParcellationOntology(Entity):
@@ -176,9 +177,9 @@ class AtlasRelease(Entity):
 @attributes(
     {
         "atlasRelease": AttrOf(AtlasRelease, default=None),
-        "about": AttrOf(list[str], default=None),
+        "about": AttrOf(List[str], default=None),
         "brainLocation": AttrOf(BrainLocation, default=None),
-        "contribution": AttrOf(list[Contribution], default=None),
+        "contribution": AttrOf(List[Contribution], default=None),
         "derivation": AttrOf(Derivation, default=None),
         "distribution": AttrOf(DataDownload),
         "subject": AttrOf(Subject, default=None),
@@ -190,10 +191,10 @@ class CellCompositionSummary(Entity):
 
 @attributes(
     {
-        "about": AttrOf(list[str], default=None),
+        "about": AttrOf(List[str], default=None),
         "atlasRelease": AttrOf(AtlasRelease, default=None),
         "brainLocation": AttrOf(BrainLocation, default=None),
-        "contribution": AttrOf(list[Contribution], default=None),
+        "contribution": AttrOf(List[Contribution], default=None),
         "derivation": AttrOf(Derivation, default=None),
         "distribution": AttrOf(DataDownload),
         "subject": AttrOf(Subject, default=None),
@@ -205,13 +206,13 @@ class CellCompositionVolume(Entity):
 
 @attributes(
     {
-        "about": AttrOf(list[str], default=None),
+        "about": AttrOf(List[str], default=None),
         "atlasRelease": AttrOf(AtlasRelease),
         "atlasSpatialReferenceSystem": AttrOf(AtlasSpatialReferenceSystem, default=None),
         "brainLocation": AttrOf(BrainLocation, default=None),
         "cellCompositionSummary": AttrOf(CellCompositionSummary),
         "cellCompositionVolume": AttrOf(CellCompositionVolume),
-        "contribution": AttrOf(list[Contribution], default=None),
+        "contribution": AttrOf(List[Contribution], default=None),
     }
 )
 class CellComposition(Entity):

--- a/entity_management/atlas.py
+++ b/entity_management/atlas.py
@@ -2,6 +2,8 @@
 
 """Atlas related entities."""
 
+from typing import List
+
 from entity_management.base import BrainLocation, Derivation, Identifiable, Subject, attributes
 from entity_management.core import Contribution, DataDownload, Entity
 from entity_management.util import AttrOf
@@ -110,7 +112,7 @@ class HemisphereAnnotationDataLayer(Entity):
 
 @attributes(
     {
-        "distribution": AttrOf(list[DataDownload]),
+        "distribution": AttrOf(List[DataDownload]),
     }
 )
 class ParcellationOntology(Entity):
@@ -175,9 +177,9 @@ class AtlasRelease(Entity):
 @attributes(
     {
         "atlasRelease": AttrOf(AtlasRelease, default=None),
-        "about": AttrOf(list[str], default=None),
+        "about": AttrOf(List[str], default=None),
         "brainLocation": AttrOf(BrainLocation, default=None),
-        "contribution": AttrOf(list[Contribution], default=None),
+        "contribution": AttrOf(List[Contribution], default=None),
         "derivation": AttrOf(Derivation, default=None),
         "distribution": AttrOf(DataDownload),
         "subject": AttrOf(Subject, default=None),
@@ -189,10 +191,10 @@ class CellCompositionSummary(Entity):
 
 @attributes(
     {
-        "about": AttrOf(list[str], default=None),
+        "about": AttrOf(List[str], default=None),
         "atlasRelease": AttrOf(AtlasRelease, default=None),
         "brainLocation": AttrOf(BrainLocation, default=None),
-        "contribution": AttrOf(list[Contribution], default=None),
+        "contribution": AttrOf(List[Contribution], default=None),
         "derivation": AttrOf(Derivation, default=None),
         "distribution": AttrOf(DataDownload),
         "subject": AttrOf(Subject, default=None),
@@ -204,13 +206,13 @@ class CellCompositionVolume(Entity):
 
 @attributes(
     {
-        "about": AttrOf(list[str], default=None),
+        "about": AttrOf(List[str], default=None),
         "atlasRelease": AttrOf(AtlasRelease),
         "atlasSpatialReferenceSystem": AttrOf(AtlasSpatialReferenceSystem, default=None),
         "brainLocation": AttrOf(BrainLocation, default=None),
         "cellCompositionSummary": AttrOf(CellCompositionSummary),
         "cellCompositionVolume": AttrOf(CellCompositionVolume),
-        "contribution": AttrOf(list[Contribution], default=None),
+        "contribution": AttrOf(List[Contribution], default=None),
     }
 )
 class CellComposition(Entity):

--- a/entity_management/base.py
+++ b/entity_management/base.py
@@ -401,7 +401,7 @@ def _deserialize_union(data_type, data_raw, *, context, base, org, proj, token):
         )
 
     # e.g. int | float | dict
-    if type(data_raw) in type_args:
+    if type(data_raw) in typecheck.get_type_root_args(data_type):
         return data_raw
 
     raise NotImplementedError(

--- a/entity_management/circuit/building/functional.py
+++ b/entity_management/circuit/building/functional.py
@@ -2,8 +2,6 @@
 
 """Entities for s2f recipe generation."""
 
-from __future__ import annotations
-
 import re
 from pathlib import Path
 

--- a/entity_management/circuit/building/functional.py
+++ b/entity_management/circuit/building/functional.py
@@ -4,6 +4,7 @@
 
 import re
 from pathlib import Path
+from typing import List, Optional, Union
 
 import attr
 
@@ -35,9 +36,9 @@ class Sample:
     """Parameters for sampling bouton density."""
 
     size: int = 100  #: Sample size
-    target: str | None = None  #: Sample target
+    target: Optional[str] = None  #: Sample target
     #: Region of interest. If provided, only axonal segments within this region would be considered.
-    mask: str | None = None
+    mask: Optional[str] = None
     assume_nsyn_bouton: float = 1.0  #: FIMXE
     assume_syns_bouton: float = 1.0  #: Assumed synapse count per bouton
 
@@ -51,22 +52,22 @@ class EstimateSynsCon(Strategy):
     formula: str  #: Synapse number prediction formula.
     #: Synapse number prediction formula for EXC->EXC pathways.
     #: If omitted, general formula would be used
-    formula_ee: str | None = None
+    formula_ee: Optional[str] = None
     #: Synapse number prediction formula for EXC->INH pathways.
     #: If omitted, general formula would be used
-    formula_ei: str | None = None
+    formula_ei: Optional[str] = None
     #: Synapse number prediction formula for INH->EXC pathways.
     #: If omitted, general formula would be used
-    formula_ie: str | None = None
+    formula_ie: Optional[str] = None
     #: Synapse number prediction formula for INH->INH pathways.
     #: If omitted, general formula would be used
-    formula_ii: str | None = None
+    formula_ii: Optional[str] = None
     #: Max value for predicted synapse number.
     #: If omitted, the predicted synapse number is not clipped above NB: predicted synapse value
     #: would be always min-clipped to 1.0 to avoid invalid synapse count values.
-    max_value: float | None = None
+    max_value: Optional[float] = None
     #: Parameters for sampling bouton density OR path to bouton-density dataset already sampled
-    sample: Sample | Path | None = None
+    sample: Union[Sample, Path, None] = None
 
 
 @attr.frozen
@@ -84,9 +85,9 @@ class EstimateBoutonReduction(Strategy):
     mtypes."""
 
     #: Path to bouton-density dataset representing reference biological data (OR single float value)
-    bio_data: Path | float
+    bio_data: Union[Path, float]
     #: Parameters for sampling bouton density OR path to bouton-density dataset already sampled
-    sample: Sample | Path | None = None
+    sample: Union[Sample, Path, None] = None
 
 
 @attr.frozen
@@ -106,14 +107,14 @@ class GeneralizedCv(Strategy):
 class Recipe:
     """Synapse pruning functionalizer recipe."""
 
-    strategies: list[
-        (
-            EstimateSynsCon
-            | ExperimentalSynsCon
-            | EstimateBoutonReduction
-            | EstimateIndividualBoutonReduction
-            | GeneralizedCv
-        )
+    strategies: List[
+        Union[
+            EstimateSynsCon,
+            ExperimentalSynsCon,
+            EstimateBoutonReduction,
+            EstimateIndividualBoutonReduction,
+            GeneralizedCv,
+        ]
     ] = []  #:
 
     def asdict(self):

--- a/entity_management/circuit/building/functional.py
+++ b/entity_management/circuit/building/functional.py
@@ -2,6 +2,8 @@
 
 """Entities for s2f recipe generation."""
 
+from __future__ import annotations
+
 import re
 from pathlib import Path
 

--- a/entity_management/cli/model_building_config.py
+++ b/entity_management/cli/model_building_config.py
@@ -86,12 +86,13 @@ def _get_ids_from_dict(config):
         id_ = _get_key(config, "id")
         type_ = _get_key(config, "type")
         if id_ and type_:
-            if rev := (_get_key(config, "_rev") or _get_key(config, "rev")):
+            rev = _get_key(config, "_rev") or _get_key(config, "rev")
+            if rev:
                 id_ = f"{id_}?rev={rev}"
             ids.add(id_)
         for key, item in config.items():
             if key not in UNALLOWED_ID_KEYS:
-                ids |= _get_ids_from_dict(item)
+                ids.update(_get_ids_from_dict(item))
 
     return ids
 
@@ -128,14 +129,15 @@ def download_and_get_ids_from_distribution(entity, path, mapping):
         distribution = [distribution]
 
     for d_item in distribution:
-        if url := d_item.get("contentUrl"):
+        url = d_item.get("contentUrl")
+        if url:
             filename = _get_distribution_filename(entity, d_item)
             print(f"    {filename}")
             download_file(url, path, file_name=filename)
             mapping[url] = filename
             if d_item.get("encodingFormat", "") == "application/json":
                 content = file_as_dict(url)
-                ids |= _get_ids_from_dict(content)
+                ids.update(_get_ids_from_dict(content))
 
     return ids
 
@@ -160,7 +162,7 @@ def _download_entity_get_ids(id_, path, mapping):
 
     entity.pop("@id", None)
     ids = _get_ids_from_dict(entity)
-    ids |= download_and_get_ids_from_distribution(entity, path, mapping)
+    ids.update(download_and_get_ids_from_distribution(entity, path, mapping))
 
     return ids
 

--- a/entity_management/context.py
+++ b/entity_management/context.py
@@ -3,6 +3,7 @@
 """Context related functions."""
 
 from __future__ import annotations
+
 from typing import Any
 
 from rdflib.plugins.shared.jsonld.context import Context

--- a/entity_management/context.py
+++ b/entity_management/context.py
@@ -2,6 +2,7 @@
 
 """Context related functions."""
 
+from __future__ import annotations
 from typing import Any
 
 from rdflib.plugins.shared.jsonld.context import Context

--- a/entity_management/core.py
+++ b/entity_management/core.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from attr.validators import in_
 
 from entity_management import nexus
+from typing import List
 
 # Subject used to be in this module. It is imported for backward compatibility
 from entity_management.base import Subject  # noqa pylint: disable=unused-import
@@ -445,12 +446,12 @@ class Contribution(BlankNode):
     {
         "name": AttrOf(str, default=None),
         "description": AttrOf(str, default=None),
-        "wasAttributedTo": AttrOf(list[Agent], default=None),
+        "wasAttributedTo": AttrOf(List[Agent], default=None),
         "wasGeneratedBy": AttrOf(Identifiable, default=None),
-        "wasDerivedFrom": AttrOf(list[Identifiable], default=None),
+        "wasDerivedFrom": AttrOf(List[Identifiable], default=None),
         "dateCreated": AttrOf(datetime, default=None),
         "distribution": AttrOf(MaybeList[DataDownload], default=None),
-        "contribution": AttrOf(list[Contribution], default=None),
+        "contribution": AttrOf(List[Contribution], default=None),
     }
 )
 class Entity(Identifiable):
@@ -549,7 +550,7 @@ class Entity(Identifiable):
 
 @attributes(
     {
-        "distribution": AttrOf(list[DataDownload], default=None),
+        "distribution": AttrOf(List[DataDownload], default=None),
     }
 )
 class MultiDistributionEntity(Entity):

--- a/entity_management/core.py
+++ b/entity_management/core.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from attr.validators import in_
 
 from entity_management import nexus
-from typing import List
 
 # Subject used to be in this module. It is imported for backward compatibility
 from entity_management.base import Subject  # noqa pylint: disable=unused-import
@@ -446,12 +445,12 @@ class Contribution(BlankNode):
     {
         "name": AttrOf(str, default=None),
         "description": AttrOf(str, default=None),
-        "wasAttributedTo": AttrOf(List[Agent], default=None),
+        "wasAttributedTo": AttrOf(list[Agent], default=None),
         "wasGeneratedBy": AttrOf(Identifiable, default=None),
-        "wasDerivedFrom": AttrOf(List[Identifiable], default=None),
+        "wasDerivedFrom": AttrOf(list[Identifiable], default=None),
         "dateCreated": AttrOf(datetime, default=None),
         "distribution": AttrOf(MaybeList[DataDownload], default=None),
-        "contribution": AttrOf(List[Contribution], default=None),
+        "contribution": AttrOf(list[Contribution], default=None),
     }
 )
 class Entity(Identifiable):
@@ -550,7 +549,7 @@ class Entity(Identifiable):
 
 @attributes(
     {
-        "distribution": AttrOf(List[DataDownload], default=None),
+        "distribution": AttrOf(list[DataDownload], default=None),
     }
 )
 class MultiDistributionEntity(Entity):

--- a/entity_management/core.py
+++ b/entity_management/core.py
@@ -14,6 +14,7 @@ import uuid
 from datetime import datetime
 from io import IOBase, StringIO
 from pathlib import Path
+from typing import List
 
 from attr.validators import in_
 
@@ -445,12 +446,12 @@ class Contribution(BlankNode):
     {
         "name": AttrOf(str, default=None),
         "description": AttrOf(str, default=None),
-        "wasAttributedTo": AttrOf(list[Agent], default=None),
+        "wasAttributedTo": AttrOf(List[Agent], default=None),
         "wasGeneratedBy": AttrOf(Identifiable, default=None),
-        "wasDerivedFrom": AttrOf(list[Identifiable], default=None),
+        "wasDerivedFrom": AttrOf(List[Identifiable], default=None),
         "dateCreated": AttrOf(datetime, default=None),
         "distribution": AttrOf(MaybeList[DataDownload], default=None),
-        "contribution": AttrOf(list[Contribution], default=None),
+        "contribution": AttrOf(List[Contribution], default=None),
     }
 )
 class Entity(Identifiable):
@@ -549,7 +550,7 @@ class Entity(Identifiable):
 
 @attributes(
     {
-        "distribution": AttrOf(list[DataDownload], default=None),
+        "distribution": AttrOf(List[DataDownload], default=None),
     }
 )
 class MultiDistributionEntity(Entity):

--- a/entity_management/emodel.py
+++ b/entity_management/emodel.py
@@ -6,8 +6,7 @@ See https://bbpgitlab.epfl.ch/dke/apps/brain-modeling-ontology/-/tree/develop/sh
 """
 
 from datetime import datetime
-
-from typing import List, Union, Dict
+from typing import Union
 
 from entity_management.atlas import AtlasRelease
 from entity_management.base import (
@@ -76,7 +75,7 @@ class ETypeAnnotation(BlankNode):
         "brainLocation": AttrOf(BrainLocation, default=None),
         "atlasRelease": AttrOf(AtlasRelease, default=None),
         "subject": AttrOf(Subject, default=None),
-        "annotation": AttrOf(List[Union[MTypeAnnotation, ETypeAnnotation]], default=None),
+        "annotation": AttrOf(list[Union[MTypeAnnotation, ETypeAnnotation]], default=None),
     }
 )
 class EModelEntity(MultiDistributionEntity):
@@ -85,7 +84,7 @@ class EModelEntity(MultiDistributionEntity):
 
 @attributes(
     {
-        "uses": AttrOf(List[Trace]),
+        "uses": AttrOf(list[Trace]),
     }
 )
 class ExtractionTargetsConfiguration(EModelEntity):
@@ -98,17 +97,17 @@ class EModelPipelineSettings(EModelEntity):
 
 @attributes(
     {
-        "distribution": AttrOf(List[DataDownload]),
-        "exposesParameter": AttrOf(List[Dict], default=None),
+        "distribution": AttrOf(list[DataDownload]),
+        "exposesParameter": AttrOf(list[dict], default=None),
         "modelId": AttrOf(str, default=None),
         "nmodlParameters": AttrOf(dict, default=None),
         "origin": AttrOf(str, default=None),
         "suffix": AttrOf(str, default=None),
-        "temperature": AttrOf(Union[int, Dict], default=None),
+        "temperature": AttrOf(Union[int, dict], default=None),
         "subject": AttrOf(Subject, default=None),
         "identifier": AttrOf(str, default=None),
-        "mod": AttrOf(Dict, default=None),
-        "ion": AttrOf(List[OntologyTerm], default=None),
+        "mod": AttrOf(dict, default=None),
+        "ion": AttrOf(list[OntologyTerm], default=None),
         "isLjpCorrected": AttrOf(bool, default=None),
         "objectOfStudy": AttrOf(OntologyTerm, default=None),
         "isTemperatureDependent": AttrOf(bool, default=None),
@@ -120,7 +119,7 @@ class SubCellularModelScript(Entity):
 
 @attributes(
     {
-        "uses": AttrOf(List[Union[NeuronMorphology, SubCellularModelScript]], default=None),
+        "uses": AttrOf(list[Union[NeuronMorphology, SubCellularModelScript]], default=None),
     }
 )
 class EModelConfiguration(EModelEntity):
@@ -129,9 +128,11 @@ class EModelConfiguration(EModelEntity):
 
 @attributes(
     {
-        "generates": AttrOf(List[Identifiable], default=None),
+        "generates": AttrOf(list[Identifiable], default=None),
         "hasPart": AttrOf(
-            List[Union[ExtractionTargetsConfiguration, EModelPipelineSettings, EModelConfiguration]],
+            list[
+                Union[ExtractionTargetsConfiguration, EModelPipelineSettings, EModelConfiguration]
+            ],
             default=None,
         ),
         "state": AttrOf(str, default=None),
@@ -181,7 +182,7 @@ class EModel(EModelEntity):
 
 @attributes(
     {
-        "hasPart": AttrOf(List[EModel]),
+        "hasPart": AttrOf(list[EModel]),
         "brainLocation": AttrOf(BrainLocation),
         "distribution": AttrOf(DataDownload),
         "subject": AttrOf(Subject, default=None),

--- a/entity_management/emodel.py
+++ b/entity_management/emodel.py
@@ -4,7 +4,6 @@
 EModel related entities.
 See https://bbpgitlab.epfl.ch/dke/apps/brain-modeling-ontology/-/tree/develop/shapes/
 """
-
 from datetime import datetime
 from typing import Union
 

--- a/entity_management/emodel.py
+++ b/entity_management/emodel.py
@@ -5,7 +5,7 @@ EModel related entities.
 See https://bbpgitlab.epfl.ch/dke/apps/brain-modeling-ontology/-/tree/develop/shapes/
 """
 from datetime import datetime
-from typing import Union
+from typing import List, Union
 
 from entity_management.atlas import AtlasRelease
 from entity_management.base import (
@@ -74,7 +74,7 @@ class ETypeAnnotation(BlankNode):
         "brainLocation": AttrOf(BrainLocation, default=None),
         "atlasRelease": AttrOf(AtlasRelease, default=None),
         "subject": AttrOf(Subject, default=None),
-        "annotation": AttrOf(list[Union[MTypeAnnotation, ETypeAnnotation]], default=None),
+        "annotation": AttrOf(List[Union[MTypeAnnotation, ETypeAnnotation]], default=None),
     }
 )
 class EModelEntity(MultiDistributionEntity):
@@ -83,7 +83,7 @@ class EModelEntity(MultiDistributionEntity):
 
 @attributes(
     {
-        "uses": AttrOf(list[Trace]),
+        "uses": AttrOf(List[Trace]),
     }
 )
 class ExtractionTargetsConfiguration(EModelEntity):
@@ -96,8 +96,8 @@ class EModelPipelineSettings(EModelEntity):
 
 @attributes(
     {
-        "distribution": AttrOf(list[DataDownload]),
-        "exposesParameter": AttrOf(list[dict], default=None),
+        "distribution": AttrOf(List[DataDownload]),
+        "exposesParameter": AttrOf(List[dict], default=None),
         "modelId": AttrOf(str, default=None),
         "nmodlParameters": AttrOf(dict, default=None),
         "origin": AttrOf(str, default=None),
@@ -106,7 +106,7 @@ class EModelPipelineSettings(EModelEntity):
         "subject": AttrOf(Subject, default=None),
         "identifier": AttrOf(str, default=None),
         "mod": AttrOf(dict, default=None),
-        "ion": AttrOf(list[OntologyTerm], default=None),
+        "ion": AttrOf(List[OntologyTerm], default=None),
         "isLjpCorrected": AttrOf(bool, default=None),
         "objectOfStudy": AttrOf(OntologyTerm, default=None),
         "isTemperatureDependent": AttrOf(bool, default=None),
@@ -118,7 +118,7 @@ class SubCellularModelScript(Entity):
 
 @attributes(
     {
-        "uses": AttrOf(list[Union[NeuronMorphology, SubCellularModelScript]], default=None),
+        "uses": AttrOf(List[Union[NeuronMorphology, SubCellularModelScript]], default=None),
     }
 )
 class EModelConfiguration(EModelEntity):
@@ -127,9 +127,9 @@ class EModelConfiguration(EModelEntity):
 
 @attributes(
     {
-        "generates": AttrOf(list[Identifiable], default=None),
+        "generates": AttrOf(List[Identifiable], default=None),
         "hasPart": AttrOf(
-            list[
+            List[
                 Union[ExtractionTargetsConfiguration, EModelPipelineSettings, EModelConfiguration]
             ],
             default=None,
@@ -181,7 +181,7 @@ class EModel(EModelEntity):
 
 @attributes(
     {
-        "hasPart": AttrOf(list[EModel]),
+        "hasPart": AttrOf(List[EModel]),
         "brainLocation": AttrOf(BrainLocation),
         "distribution": AttrOf(DataDownload),
         "subject": AttrOf(Subject, default=None),

--- a/entity_management/emodel.py
+++ b/entity_management/emodel.py
@@ -7,6 +7,8 @@ See https://bbpgitlab.epfl.ch/dke/apps/brain-modeling-ontology/-/tree/develop/sh
 
 from datetime import datetime
 
+from typing import List, Union, Dict
+
 from entity_management.atlas import AtlasRelease
 from entity_management.base import (
     BlankNode,
@@ -74,7 +76,7 @@ class ETypeAnnotation(BlankNode):
         "brainLocation": AttrOf(BrainLocation, default=None),
         "atlasRelease": AttrOf(AtlasRelease, default=None),
         "subject": AttrOf(Subject, default=None),
-        "annotation": AttrOf(list[MTypeAnnotation | ETypeAnnotation], default=None),
+        "annotation": AttrOf(List[Union[MTypeAnnotation, ETypeAnnotation]], default=None),
     }
 )
 class EModelEntity(MultiDistributionEntity):
@@ -83,7 +85,7 @@ class EModelEntity(MultiDistributionEntity):
 
 @attributes(
     {
-        "uses": AttrOf(list[Trace]),
+        "uses": AttrOf(List[Trace]),
     }
 )
 class ExtractionTargetsConfiguration(EModelEntity):
@@ -96,17 +98,17 @@ class EModelPipelineSettings(EModelEntity):
 
 @attributes(
     {
-        "distribution": AttrOf(list[DataDownload]),
-        "exposesParameter": AttrOf(list[dict], default=None),
+        "distribution": AttrOf(List[DataDownload]),
+        "exposesParameter": AttrOf(List[Dict], default=None),
         "modelId": AttrOf(str, default=None),
         "nmodlParameters": AttrOf(dict, default=None),
         "origin": AttrOf(str, default=None),
         "suffix": AttrOf(str, default=None),
-        "temperature": AttrOf(int | dict, default=None),
+        "temperature": AttrOf(Union[int, Dict], default=None),
         "subject": AttrOf(Subject, default=None),
         "identifier": AttrOf(str, default=None),
-        "mod": AttrOf(dict, default=None),
-        "ion": AttrOf(list[OntologyTerm], default=None),
+        "mod": AttrOf(Dict, default=None),
+        "ion": AttrOf(List[OntologyTerm], default=None),
         "isLjpCorrected": AttrOf(bool, default=None),
         "objectOfStudy": AttrOf(OntologyTerm, default=None),
         "isTemperatureDependent": AttrOf(bool, default=None),
@@ -118,7 +120,7 @@ class SubCellularModelScript(Entity):
 
 @attributes(
     {
-        "uses": AttrOf(list[NeuronMorphology | SubCellularModelScript], default=None),
+        "uses": AttrOf(List[Union[NeuronMorphology, SubCellularModelScript]], default=None),
     }
 )
 class EModelConfiguration(EModelEntity):
@@ -127,9 +129,9 @@ class EModelConfiguration(EModelEntity):
 
 @attributes(
     {
-        "generates": AttrOf(list[Identifiable], default=None),
+        "generates": AttrOf(List[Identifiable], default=None),
         "hasPart": AttrOf(
-            list[ExtractionTargetsConfiguration | EModelPipelineSettings | EModelConfiguration],
+            List[Union[ExtractionTargetsConfiguration, EModelPipelineSettings, EModelConfiguration]],
             default=None,
         ),
         "state": AttrOf(str, default=None),
@@ -179,7 +181,7 @@ class EModel(EModelEntity):
 
 @attributes(
     {
-        "hasPart": AttrOf(list[EModel]),
+        "hasPart": AttrOf(List[EModel]),
         "brainLocation": AttrOf(BrainLocation),
         "distribution": AttrOf(DataDownload),
         "subject": AttrOf(Subject, default=None),

--- a/entity_management/nexus.py
+++ b/entity_management/nexus.py
@@ -217,7 +217,7 @@ def update(id_url, rev, payload, sync_index=False, token=None):
     assert rev > 0
     params = {"rev": rev}
     if sync_index:
-        params |= {"indexing": "sync"}
+        params.update({"indexing": "sync"})
     response = requests.put(
         id_url, headers=_get_headers(token), params=params, json=payload, timeout=10
     )
@@ -232,7 +232,7 @@ def deprecate(id_url, rev, sync_index=False, token=None):
     assert rev > 0
     params = {"rev": rev}
     if sync_index:
-        params |= {"indexing": "sync"}
+        params.update({"indexing": "sync"})
     response = requests.delete(id_url, headers=_get_headers(token), params=params, timeout=10)
     response.raise_for_status()
     return _to_json(response)
@@ -297,7 +297,7 @@ def load_by_id(
 
     if params is None:
         params = {}
-    params |= revision_query
+    params.update(revision_query)
 
     url = f"{base_url}/{quote(resource_id)}"
     return load_by_url(url=url, params=params, stream=stream, token=token)

--- a/entity_management/simulation.py
+++ b/entity_management/simulation.py
@@ -3,7 +3,7 @@
 """Simulation domain entities."""
 
 from datetime import datetime
-from typing import Union
+from typing import List, Union
 
 from attr.validators import in_
 
@@ -151,7 +151,7 @@ class SingleCellSimulationTrace(Entity):
     """Single cell simulation trace file"""
 
 
-@attributes({"hadMember": AttrOf(list[Trace], default=None)})
+@attributes({"hadMember": AttrOf(List[Trace], default=None)})
 class TraceCollection(Entity):
     """Collection of traces
 
@@ -160,7 +160,7 @@ class TraceCollection(Entity):
     """
 
 
-@attributes({"hadMember": AttrOf(list[Trace], default=None)})
+@attributes({"hadMember": AttrOf(List[Trace], default=None)})
 class CoreTraceCollection(Entity):
     """Collection of traces
 
@@ -204,7 +204,7 @@ class BluePyEfeFeatures(Entity):
         "subject": AttrOf(Subject, default=None),
         "mType": AttrOf(OntologyTerm),
         "eType": AttrOf(OntologyTerm),
-        "experimentalCell": AttrOf(list[ExperimentalCell]),
+        "experimentalCell": AttrOf(List[ExperimentalCell]),
         "featureExtractionConfiguration": AttrOf(dict),
         "stimuliToExperimentMap": AttrOf(dict, default=None),
     }
@@ -326,7 +326,7 @@ class EModelGenerationShape(Entity):
 
 @attributes(
     {
-        "used": AttrOf(list[Union[CoreTraceCollection, BluePyEfeConfiguration]]),
+        "used": AttrOf(List[Union[CoreTraceCollection, BluePyEfeConfiguration]]),
         "generated": AttrOf(BluePyEfeFeatures, default=None),
     }
 )
@@ -478,7 +478,7 @@ class SimulationCampaignGeneration(BbpWorkflowActivity):
 
 @attributes(
     {
-        "hadMember": AttrOf(list[Report], default=None),
+        "hadMember": AttrOf(List[Report], default=None),
     }
 )
 class SimulationCampaignReportCollection(Entity):
@@ -536,7 +536,7 @@ class AnalysisConfiguration(Entity):
 
 @attributes(
     {
-        "used": AttrOf(list[Identifiable], default=None),
+        "used": AttrOf(List[Identifiable], default=None),
     }
 )
 class Analysis(Activity):
@@ -549,7 +549,7 @@ class Analysis(Activity):
 
 @attributes(
     {
-        "used": AttrOf(list[VariableReport], default=None),
+        "used": AttrOf(List[VariableReport], default=None),
         "generated": AttrOf(AnalysisReport, default=None),
         # 'wasInformedBy': AttrOf(SimulationCampaign, default=None),
     }

--- a/entity_management/simulation.py
+++ b/entity_management/simulation.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Union
 
 from attr.validators import in_
+from typing import List, Dict
 
 from entity_management import morphology
 from entity_management.atlas import AtlasRelease
@@ -151,7 +152,7 @@ class SingleCellSimulationTrace(Entity):
     """Single cell simulation trace file"""
 
 
-@attributes({"hadMember": AttrOf(list[Trace], default=None)})
+@attributes({"hadMember": AttrOf(List[Trace], default=None)})
 class TraceCollection(Entity):
     """Collection of traces
 
@@ -160,7 +161,7 @@ class TraceCollection(Entity):
     """
 
 
-@attributes({"hadMember": AttrOf(list[Trace], default=None)})
+@attributes({"hadMember": AttrOf(List[Trace], default=None)})
 class CoreTraceCollection(Entity):
     """Collection of traces
 
@@ -204,9 +205,9 @@ class BluePyEfeFeatures(Entity):
         "subject": AttrOf(Subject, default=None),
         "mType": AttrOf(OntologyTerm),
         "eType": AttrOf(OntologyTerm),
-        "experimentalCell": AttrOf(list[ExperimentalCell]),
-        "featureExtractionConfiguration": AttrOf(dict),
-        "stimuliToExperimentMap": AttrOf(dict, default=None),
+        "experimentalCell": AttrOf(List[ExperimentalCell]),
+        "featureExtractionConfiguration": AttrOf(Dict),
+        "stimuliToExperimentMap": AttrOf(Dict, default=None),
     }
 )
 class BluePyEfeConfiguration(Entity):
@@ -326,7 +327,7 @@ class EModelGenerationShape(Entity):
 
 @attributes(
     {
-        "used": AttrOf(list[Union[CoreTraceCollection, BluePyEfeConfiguration]]),
+        "used": AttrOf(List[Union[CoreTraceCollection, BluePyEfeConfiguration]]),
         "generated": AttrOf(BluePyEfeFeatures, default=None),
     }
 )
@@ -377,7 +378,7 @@ class VariableReport(Report):
 
 @attributes(
     {
-        "parameter": AttrOf(dict),
+        "parameter": AttrOf(Dict),
         "startedAtTime": AttrOf(datetime, default=None),
         "endedAtTime": AttrOf(datetime, default=None),
         "status": AttrOf(
@@ -478,7 +479,7 @@ class SimulationCampaignGeneration(BbpWorkflowActivity):
 
 @attributes(
     {
-        "hadMember": AttrOf(list[Report], default=None),
+        "hadMember": AttrOf(List[Report], default=None),
     }
 )
 class SimulationCampaignReportCollection(Entity):
@@ -536,7 +537,7 @@ class AnalysisConfiguration(Entity):
 
 @attributes(
     {
-        "used": AttrOf(list[Identifiable], default=None),
+        "used": AttrOf(List[Identifiable], default=None),
     }
 )
 class Analysis(Activity):
@@ -549,7 +550,7 @@ class Analysis(Activity):
 
 @attributes(
     {
-        "used": AttrOf(list[VariableReport], default=None),
+        "used": AttrOf(List[VariableReport], default=None),
         "generated": AttrOf(AnalysisReport, default=None),
         # 'wasInformedBy': AttrOf(SimulationCampaign, default=None),
     }
@@ -582,7 +583,7 @@ class PlotCollection(MultiDistributionEntity):
 @attributes(
     {
         "simulations": AttrOf(DataDownload),
-        "parameter": AttrOf(dict, default={}),
+        "parameter": AttrOf(Dict, default={}),
     }
 )
 class SimulationCampaign(Entity):

--- a/entity_management/simulation.py
+++ b/entity_management/simulation.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from typing import Union
 
 from attr.validators import in_
-from typing import List, Dict
 
 from entity_management import morphology
 from entity_management.atlas import AtlasRelease
@@ -152,7 +151,7 @@ class SingleCellSimulationTrace(Entity):
     """Single cell simulation trace file"""
 
 
-@attributes({"hadMember": AttrOf(List[Trace], default=None)})
+@attributes({"hadMember": AttrOf(list[Trace], default=None)})
 class TraceCollection(Entity):
     """Collection of traces
 
@@ -161,7 +160,7 @@ class TraceCollection(Entity):
     """
 
 
-@attributes({"hadMember": AttrOf(List[Trace], default=None)})
+@attributes({"hadMember": AttrOf(list[Trace], default=None)})
 class CoreTraceCollection(Entity):
     """Collection of traces
 
@@ -205,9 +204,9 @@ class BluePyEfeFeatures(Entity):
         "subject": AttrOf(Subject, default=None),
         "mType": AttrOf(OntologyTerm),
         "eType": AttrOf(OntologyTerm),
-        "experimentalCell": AttrOf(List[ExperimentalCell]),
-        "featureExtractionConfiguration": AttrOf(Dict),
-        "stimuliToExperimentMap": AttrOf(Dict, default=None),
+        "experimentalCell": AttrOf(list[ExperimentalCell]),
+        "featureExtractionConfiguration": AttrOf(dict),
+        "stimuliToExperimentMap": AttrOf(dict, default=None),
     }
 )
 class BluePyEfeConfiguration(Entity):
@@ -327,7 +326,7 @@ class EModelGenerationShape(Entity):
 
 @attributes(
     {
-        "used": AttrOf(List[Union[CoreTraceCollection, BluePyEfeConfiguration]]),
+        "used": AttrOf(list[Union[CoreTraceCollection, BluePyEfeConfiguration]]),
         "generated": AttrOf(BluePyEfeFeatures, default=None),
     }
 )
@@ -378,7 +377,7 @@ class VariableReport(Report):
 
 @attributes(
     {
-        "parameter": AttrOf(Dict),
+        "parameter": AttrOf(dict),
         "startedAtTime": AttrOf(datetime, default=None),
         "endedAtTime": AttrOf(datetime, default=None),
         "status": AttrOf(
@@ -479,7 +478,7 @@ class SimulationCampaignGeneration(BbpWorkflowActivity):
 
 @attributes(
     {
-        "hadMember": AttrOf(List[Report], default=None),
+        "hadMember": AttrOf(list[Report], default=None),
     }
 )
 class SimulationCampaignReportCollection(Entity):
@@ -537,7 +536,7 @@ class AnalysisConfiguration(Entity):
 
 @attributes(
     {
-        "used": AttrOf(List[Identifiable], default=None),
+        "used": AttrOf(list[Identifiable], default=None),
     }
 )
 class Analysis(Activity):
@@ -550,7 +549,7 @@ class Analysis(Activity):
 
 @attributes(
     {
-        "used": AttrOf(List[VariableReport], default=None),
+        "used": AttrOf(list[VariableReport], default=None),
         "generated": AttrOf(AnalysisReport, default=None),
         # 'wasInformedBy': AttrOf(SimulationCampaign, default=None),
     }
@@ -583,7 +582,7 @@ class PlotCollection(MultiDistributionEntity):
 @attributes(
     {
         "simulations": AttrOf(DataDownload),
-        "parameter": AttrOf(Dict, default={}),
+        "parameter": AttrOf(dict, default={}),
     }
 )
 class SimulationCampaign(Entity):

--- a/entity_management/typecheck.py
+++ b/entity_management/typecheck.py
@@ -2,9 +2,9 @@
 
 """Type checking related utils."""
 
-import sys
-import inspect
 import collections.abc
+import inspect
+import sys
 import types
 import typing
 
@@ -18,6 +18,14 @@ def get_type_root_class(data_type):
         return typing.Union
 
     return root_type
+
+
+def get_type_root_args(data_type):
+    """Return the type's args as type classes.
+
+    For example list | Dict returns (list, dict).
+    """
+    return tuple(get_type_root_class(arg) for arg in typing.get_args(data_type))
 
 
 def is_type_sequence(data_type):

--- a/entity_management/typecheck.py
+++ b/entity_management/typecheck.py
@@ -2,6 +2,8 @@
 
 """Type checking related utils."""
 
+import sys
+import inspect
 import collections.abc
 import types
 import typing
@@ -11,18 +13,23 @@ def get_type_root_class(data_type):
     """Get type class. First try if it's `typing` type class then fallback to regular type."""
     root_type = typing.get_origin(data_type) or data_type
 
-    # Return types.UnionType instead of typing.Union because it works with issubclass
-    if root_type is typing.Union:
-        return types.UnionType
+    # types.UnionType for A | B is added in python3.10
+    if sys.version_info.minor >= 10 and root_type is types.UnionType:
+        return typing.Union
 
     return root_type
 
 
 def is_type_sequence(data_type):
     """Return True if the data_type is a sequence."""
-    return data_type is not str and issubclass(
+    return data_type is not str and _issubclass(
         get_type_root_class(data_type), collections.abc.Sequence
     )
+
+
+def _issubclass(x, y):
+    """Return True if x is a class that is a subclass of y."""
+    return inspect.isclass(x) and issubclass(x, y)
 
 
 def is_data_sequence(data_raw):
@@ -32,7 +39,7 @@ def is_data_sequence(data_raw):
 
 def is_type_mapping(data_type):
     """Return True if the data_type is a mapping."""
-    return issubclass(get_type_root_class(data_type), collections.abc.Mapping)
+    return _issubclass(get_type_root_class(data_type), collections.abc.Mapping)
 
 
 def is_data_mapping(data_raw):
@@ -42,7 +49,9 @@ def is_data_mapping(data_raw):
 
 def is_type_union(data_type):
     """Return True if the data_type is a union."""
-    return get_type_root_class(data_type) in {typing.Union, types.UnionType}
+    if sys.version_info.minor >= 10:
+        return get_type_root_class(data_type) in {typing.Union, types.UnionType}
+    return get_type_root_class(data_type) is typing.Union
 
 
 def is_type_single_or_list_union(data_type):
@@ -58,6 +67,6 @@ def is_type_single_or_list_union(data_type):
     arg2_origin = typing.get_origin(arg2)
     return (
         arg2_origin is not None
-        and issubclass(arg2_origin, list)
+        and _issubclass(arg2_origin, list)
         and arg1 is typing.get_args(arg2)[0]
     )

--- a/entity_management/typecheck.py
+++ b/entity_management/typecheck.py
@@ -14,7 +14,7 @@ def get_type_root_class(data_type):
     root_type = typing.get_origin(data_type) or data_type
 
     # types.UnionType for A | B is added in python3.10
-    if sys.version_info.minor >= 10 and root_type is types.UnionType:
+    if sys.version_info >= (3, 10) and root_type is types.UnionType:  # pylint: disable=no-member
         return typing.Union
 
     return root_type
@@ -58,6 +58,7 @@ def is_data_mapping(data_raw):
 def is_type_union(data_type):
     """Return True if the data_type is a union."""
     if sys.version_info.minor >= 10:
+        # pylint: disable=no-member
         return get_type_root_class(data_type) in {typing.Union, types.UnionType}
     return get_type_root_class(data_type) is typing.Union
 

--- a/entity_management/typing.py
+++ b/entity_management/typing.py
@@ -6,4 +6,4 @@ import typing
 
 T = typing.TypeVar("T")
 
-MaybeList = T | list[T]
+MaybeList = typing.Union[T, typing.List[T]]

--- a/entity_management/typing.py
+++ b/entity_management/typing.py
@@ -6,4 +6,4 @@ import typing
 
 T = typing.TypeVar("T")
 
-MaybeList = typing.Union[T, list[T]]
+MaybeList = typing.Union[T, typing.List[T]]

--- a/entity_management/typing.py
+++ b/entity_management/typing.py
@@ -6,4 +6,4 @@ import typing
 
 T = typing.TypeVar("T")
 
-MaybeList = typing.Union[T, typing.List[T]]
+MaybeList = typing.Union[T, list[T]]

--- a/entity_management/util.py
+++ b/entity_management/util.py
@@ -3,6 +3,7 @@
 """Utilities"""
 
 from __future__ import annotations
+
 import typing
 from urllib.parse import parse_qs
 from urllib.parse import quote as parse_quote
@@ -160,11 +161,14 @@ def _make_validators(type_, default, custom_validators):
             validator = _list_of(types, default)
         else:
             validator = _list_of(list_element_type, default)
-
     # e.g. A | list[A]
     elif typecheck.is_type_single_or_list_union(type_):
         element_type = typing.get_args(type_)[0]
         validator = _one_or_list_of(element_type, default)
+    # e.g A | B
+    elif typecheck.is_type_union(type_):
+        types = _get_union_params(type_)
+        validator = instance_of(types)
     else:
         if default is None:  # default explicitly provided as None
             validator = optional_of(type_)

--- a/entity_management/util.py
+++ b/entity_management/util.py
@@ -2,8 +2,6 @@
 
 """Utilities"""
 
-from __future__ import annotations
-
 import typing
 from urllib.parse import parse_qs
 from urllib.parse import quote as parse_quote

--- a/entity_management/util.py
+++ b/entity_management/util.py
@@ -3,6 +3,7 @@
 """Utilities"""
 
 import typing
+from typing import Optional
 from urllib.parse import parse_qs
 from urllib.parse import quote as parse_quote
 from urllib.parse import unquote, urlparse
@@ -227,10 +228,10 @@ def get_entity(
     cls,
     cross_bucket: bool = True,
     resolve_context: bool = False,
-    base: str | None = None,
-    org: str | None = None,
-    proj: str | None = None,
-    token: str | None = None,
+    base: Optional[str] = None,
+    org: Optional[str] = None,
+    proj: Optional[str] = None,
+    token: Optional[str] = None,
 ):
     """Instantiate an entity from a resource id.
 

--- a/entity_management/util.py
+++ b/entity_management/util.py
@@ -2,6 +2,7 @@
 
 """Utilities"""
 
+from __future__ import annotations
 import typing
 from urllib.parse import parse_qs
 from urllib.parse import quote as parse_quote

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 name = "entity-management"
 description = "Access to production entity management"
 readme = { file = "README.rst", content-type = "text/x-rst" }
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 license = { file = "LICENSE.txt" }
 authors = [
   { name = "Blue Brain Project, EPFL" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,11 @@ local_scheme = "no-local-version"
 [tool.black]
 line-length = 100
 target-version = [
+    'py38',
+    'py39',
     'py310',
+    'py311',
+    'py312',
 ]
 include = 'entity_management\/.*\.py$|tests\/.*\.py$|doc\/source\/conf\.py$|setup\.py$'
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -4,12 +4,10 @@ from entity_management import state as test_module
 
 def test_refresh_token__no_offline_token():
     """Test that refreshing is not attempted if no OFFLINE_TOKEN"""
-    with (
-        patch("entity_management.state.ACCESS_TOKEN", "my-token"),
-        patch("entity_management.state.OFFLINE_TOKEN", None),
-    ):
-        token = test_module.refresh_token()
-        assert token == "my-token"
+    with patch("entity_management.state.ACCESS_TOKEN", "my-token"):
+        with patch("entity_management.state.OFFLINE_TOKEN", None):
+            token = test_module.refresh_token()
+            assert token == "my-token"
 
 
 def test_get_base_resolvers():
@@ -24,13 +22,11 @@ def test_get_base_resolvers__None():
 
 
 def test_base_url__cross_bucket():
-    with (
-        patch("entity_management.state.BASE", "my-base"),
-        patch("entity_management.state.PROJ", "my-proj"),
-        patch("entity_management.state.ORG", "my-org"),
-    ):
-        res = test_module.get_base_url()
-        assert res == "my-base/resources/my-org/my-proj/_"
+    with patch("entity_management.state.BASE", "my-base"):
+        with patch("entity_management.state.PROJ", "my-proj"):
+            with patch("entity_management.state.ORG", "my-org"):
+                res = test_module.get_base_url()
+                assert res == "my-base/resources/my-org/my-proj/_"
 
-        res = test_module.get_base_url(cross_bucket=True)
-        assert res == "my-base/resolvers/my-org/my-proj/_"
+                res = test_module.get_base_url(cross_bucket=True)
+                assert res == "my-base/resolvers/my-org/my-proj/_"

--- a/tests/test_typecheck.py
+++ b/tests/test_typecheck.py
@@ -27,15 +27,47 @@ def _eval(string_or_type):
     "type_,expected",
     [
         (int, int),
+        (list, list),
         (List[int], list),
         _skip("list[int]", list, min_version=(3, 9)),
+        (tuple, tuple),
+        (Tuple[float], tuple),
+        _skip("tuple[int]", tuple, min_version=(3, 9)),
+        (Dict[float, int], dict),
+        _skip("dict[float, int]", dict, min_version=(3, 9)),
         (Union[int, float], Union),
         _skip("int | float", Union, min_version=(3, 10)),
     ],
 )
-def test_type_root_class(type_, expected):
+def test_get_type_root_class(type_, expected):
     res = test_module.get_type_root_class(_eval(type_))
     assert res is expected
+
+
+@pytest.mark.parametrize(
+    "type_,expected",
+    [
+        (List[int], (int,)),
+        _skip("list[int]", (int,), min_version=(3, 9)),
+        (List[List], (list,)),
+        _skip("list[list]", (list,), min_version=(3, 9)),
+        _skip("list[List]", (list,), min_version=(3, 9)),
+        (Dict[int, float], (int, float)),
+        (Dict[list, dict], (list, dict)),
+        (Dict[List, dict], (list, dict)),
+        _skip("dict[int, float]", (int, float), min_version=(3, 9)),
+        _skip("dict[List, Dict]", (list, dict), min_version=(3, 9)),
+        (Union[int, float], (int, float)),
+        _skip("int | float", (int, float), min_version=(3, 10)),
+        (Union[List, Dict], (list, dict)),
+        _skip("List | Dict", (list, dict), min_version=(3, 10)),
+        (Union[list, dict], (list, dict)),
+        _skip("list | dict", (list, dict), min_version=(3, 10)),
+    ],
+)
+def test_get_type_root_args(type_, expected):
+    res = test_module.get_type_root_args(_eval(type_))
+    assert res == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 import attr
 
+import sys
 import pytest
 from entity_management import exception
 from entity_management import util as test_module
@@ -33,6 +34,7 @@ OBN2 = BN2(a=2)
 OBN3 = BN3(a=3)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10))
 @pytest.mark.parametrize(
     "type_,default,value, should_validation_pass",
     [

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@ testdeps =
 
 [tox]
 envlist =
-    check-packaging
     lint
+    coverage
+    check-packaging
     py{38,39,310,311,312}
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ testdeps =
 envlist =
     check-packaging
     lint
-    py3
+    py{38,39,310,311,312}
 
 [testenv]
 deps = {[base]testdeps}

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,6 @@ deps =
     isort
     black
 commands =
-    find {[base]name} -type f -name '*.py' -exec pyupgrade --py310-plus {} ;
     autoflake -ir --remove-all-unused-imports --ignore-init-module-imports {[base]name}
     isort {[base]name}
     black .

--- a/tox.ini
+++ b/tox.ini
@@ -75,3 +75,11 @@ allowlist_externals = make
 [pycodestyle]
 ignore = E731,W503,W504
 max-line-length = 100
+
+[gh-actions]
+python =
+    3.8: py38, lint
+    3.9: py39
+    3.10: py310, docs, check-packaging
+    3.11: py311, coverage
+    3.12: py312, check-packaging


### PR DESCRIPTION
Allow entity-management to work with all pythons: python3.8 - python3.12
Closes #6 

Summary:
* Reverted to using typing's List, Dict, Union instead of newer generics  and '|' syntax in python3.9/python3.10
* Adapted the typecheck system to work with typing.Union instead of types.UnionType that is available in python3.10+
* Added conditional tests on python version to check functionality with old and newer syntax combinations