### PR TITLE
Support tags in linked entities

### DIFF
--- a/entity_management/base.py
+++ b/entity_management/base.py
@@ -532,7 +532,14 @@ class Identifiable(Frozen, metaclass=_IdentifiableMeta):
 
     @classmethod
     def _lazy_init(
-        cls, resource_id, type_=NotInstantiated, rev=NotInstantiated, tag=NotInstantiated, base=None, org=None, proj=None
+        cls,
+        resource_id,
+        type_=NotInstantiated,
+        rev=NotInstantiated,
+        tag=NotInstantiated,
+        base=None,
+        org=None,
+        proj=None,
     ):
         """Instantiate an object and put all its attributes to NotInstantiated."""
         # Running the validator has the side effect of instantiating

--- a/entity_management/base.py
+++ b/entity_management/base.py
@@ -23,6 +23,7 @@ from entity_management.settings import (
     JSLD_CTX,
     JSLD_ID,
     JSLD_LINK_REV,
+    JSLD_LINK_TAG,
     JSLD_TYPE,
     NSG,
     NXV,
@@ -414,6 +415,7 @@ def _deserialize_identifiable(data_type, data_raw, *, base, org, proj, token):
     resource_id = data_raw[JSLD_ID]
     type_ = data_raw[JSLD_TYPE]
     rev = data_raw.get(JSLD_LINK_REV, NotInstantiated)
+    tag = data_raw.get(JSLD_LINK_TAG, NotInstantiated)
 
     # if generic Identifiable class is declared find the more specific type
     if data_type is Identifiable:
@@ -426,7 +428,7 @@ def _deserialize_identifiable(data_type, data_raw, *, base, org, proj, token):
                 resource_id, base, org, proj, token=token, cross_bucket=True
             )
 
-    return data_type._lazy_init(resource_id, type_, rev=rev, base=base, org=org, proj=proj)
+    return data_type._lazy_init(resource_id, type_, rev=rev, tag=tag, base=base, org=org, proj=proj)
 
 
 def _deserialize_frozen(data_type, data_raw, context, base, org, proj, token):
@@ -524,12 +526,13 @@ class Identifiable(Frozen, metaclass=_IdentifiableMeta):
     _deprecated = NotInstantiated
     _project = NotInstantiated
     _rev = NotInstantiated
+    _tag = NotInstantiated
     _updatedAt = NotInstantiated
     _updatedBy = NotInstantiated
 
     @classmethod
     def _lazy_init(
-        cls, resource_id, type_=NotInstantiated, rev=NotInstantiated, base=None, org=None, proj=None
+        cls, resource_id, type_=NotInstantiated, rev=NotInstantiated, tag=NotInstantiated, base=None, org=None, proj=None
     ):
         """Instantiate an object and put all its attributes to NotInstantiated."""
         # Running the validator has the side effect of instantiating
@@ -539,6 +542,7 @@ class Identifiable(Frozen, metaclass=_IdentifiableMeta):
         obj._force_attr("_id", resource_id)
         obj._force_attr("_type", type_)
         obj._force_attr("_rev", rev)
+        obj._force_attr("_tag", tag)
         obj._force_attr("_lazy_meta_", (base, org, proj))
         attr.set_run_validators(True)
         return obj
@@ -772,9 +776,18 @@ class Identifiable(Frozen, metaclass=_IdentifiableMeta):
         else:
             base, org, proj = (None, None, None)
 
-        # use the revision in the retrieval if it's a priori available
+        # use the revision or tag in the retrieval if they are priori available
+        tag = object.__getattribute__(self, "_tag")
         rev = object.__getattribute__(self, "_rev")
-        resource_id = self._id if rev is NotInstantiated else f"{self._id}?rev={rev}"
+
+        # note that tag is given precedence over _rev becauce it avoids replaying history up to that
+        # revision, and is therefore faster
+        if tag is not NotInstantiated:
+            resource_id = f"{self._id}?tag={tag}"
+        elif rev is not NotInstantiated:
+            resource_id = f"{self._id}?rev={rev}"
+        else:
+            resource_id = self._id
 
         fetched_instance = type(self).from_id(
             resource_id, base=base, org=org, proj=proj, cross_bucket=True

--- a/entity_management/cli/base.py
+++ b/entity_management/cli/base.py
@@ -14,7 +14,7 @@ from entity_management.cli.model_building_config import (
 )
 from entity_management.config import ModelBuildingConfig
 from entity_management.nexus import load_by_id, load_by_url
-from entity_management.util import split_url_from_revision_query
+from entity_management.util import split_url_params
 
 
 @click.group()
@@ -58,7 +58,7 @@ def get(id_or_url, output, max_depth):
     if not_set := [v for v in ("NEXUS_TOKEN", "NEXUS_ORG", "NEXUS_PROJ") if not os.getenv(v)]:
         raise click.ClickException(f"Variable(s) {', '.join(not_set)} not set in environment.")
 
-    id_or_url, _ = split_url_from_revision_query(id_or_url)
+    id_or_url, _ = split_url_params(id_or_url)
 
     # In all tested cases `load_by_url` worked with the ID. `load_by_id` kept as a backup
     data = load_by_url(id_or_url) or load_by_id(id_or_url, cross_bucket=True)

--- a/entity_management/nexus.py
+++ b/entity_management/nexus.py
@@ -24,7 +24,7 @@ from entity_management.state import (
     has_offline_token,
     refresh_token,
 )
-from entity_management.util import PP, quote, split_url_from_revision_query, unquote_uri_path
+from entity_management.util import PP, quote, split_url_params, unquote_uri_path
 
 L = logging.getLogger(__name__)
 

--- a/entity_management/nexus.py
+++ b/entity_management/nexus.py
@@ -293,11 +293,12 @@ def load_by_id(
     """
     base_url = get_base_url(base=base, org=org, proj=proj, cross_bucket=cross_bucket)
 
-    resource_id, revision_query = split_url_from_revision_query(resource_id)
+    resource_id, url_params = split_url_params(resource_id)
 
     if params is None:
         params = {}
-    params.update(revision_query)
+
+    params.update(url_params)
 
     url = f"{base_url}/{quote(resource_id)}"
     return load_by_url(url=url, params=params, stream=stream, token=token)

--- a/entity_management/settings.py
+++ b/entity_management/settings.py
@@ -11,6 +11,7 @@ JSLD_TYPE = "@type"
 JSLD_CTX = "@context"
 JSLD_REV = "nxv:rev"
 JSLD_LINK_REV = "_rev"
+JSLD_LINK_TAG = "tag"
 JSLD_DEPRECATED = "nxv:deprecated"
 
 USERINFO = os.getenv("NEXUS_USERINFO", "https://bbp.epfl.ch/nexus/v1/identities")

--- a/entity_management/state.py
+++ b/entity_management/state.py
@@ -62,6 +62,7 @@ def set_token(token):
     if token is None:
         return
 
+    # pylint: disable=unreachable
     token_info = jwt.decode(token, options={"verify_signature": False})
 
     if token_info["typ"] == "Bearer":

--- a/entity_management/util.py
+++ b/entity_management/util.py
@@ -194,12 +194,12 @@ def quote(url):
     return parse_quote(url, safe="")
 
 
-def split_url_from_revision_query(url):
+def split_url_params(url):
     """Split url from revision query."""
     res = urlparse(url)
-    url_without_revision = f"{res.scheme}://{res.netloc}{res.path}"
-    revision_query = parse_qs(res.query)
-    return url_without_revision, revision_query
+    url = f"{res.scheme}://{res.netloc}{res.path}"
+    params = parse_qs(res.query)
+    return url, params
 
 
 class PP:

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -144,7 +144,7 @@ def test_load_by_id__cross_bucket():
         )
 
 
-def test_lod_by_id__with_revision():
+def test_load_by_id__with_revision():
     resource_id = "https://bbp.epfl.ch/neurosciencegraph/data/1"
     resource_id_with_revision = f"{resource_id}?rev=5"
     with patch("entity_management.nexus.load_by_url") as patched:
@@ -158,6 +158,25 @@ def test_lod_by_id__with_revision():
         patched.assert_called_once_with(
             url=f"my-base/resolvers/my-org/my-proj/_/{quote(resource_id)}",
             params={"rev": ["5"]},
+            stream=False,
+            token=None,
+        )
+
+
+def test_load_by_id__with_tag():
+    resource_id = "https://bbp.epfl.ch/neurosciencegraph/data/1"
+    resource_id_with_revision = f"{resource_id}?tag=v1.1"
+    with patch("entity_management.nexus.load_by_url") as patched:
+        nexus.load_by_id(
+            resource_id_with_revision,
+            base="my-base",
+            org="my-org",
+            proj="my-proj",
+            cross_bucket=True,
+        )
+        patched.assert_called_once_with(
+            url=f"my-base/resolvers/my-org/my-proj/_/{quote(resource_id)}",
+            params={"tag": ["v1.1"]},
             stream=False,
             token=None,
         )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -152,10 +152,10 @@ def test_url_params():
 
     url = "https://foo/bar?rev=10"
     res_url, res_params = test_module.split_url_params(url)
-    assert res_url == 'https://foo/bar'
-    assert res_params == {'rev': ['10']}
+    assert res_url == "https://foo/bar"
+    assert res_params == {"rev": ["10"]}
 
     url = "https://foo/bar?tag=v1.1"
     res_url, res_params = test_module.split_url_params(url)
-    assert res_url == 'https://foo/bar'
-    assert res_params == {'tag': ['v1.1']}
+    assert res_url == "https://foo/bar"
+    assert res_params == {"tag": ["v1.1"]}

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -146,3 +146,16 @@ def test_get_entity__raises_if_not_instantiated(patched):
         exception.EntityNotInstantiatedError, match="failed to be instantiated from id my-id"
     ):
         test_module.get_entity("my-id", cls=MyEntity)
+
+
+def test_url_params():
+
+    url = "https://foo/bar?rev=10"
+    res_url, res_params = test_module.split_url_params(url)
+    assert res_url == 'https://foo/bar'
+    assert res_params == {'rev': ['10']}
+
+    url = "https://foo/bar?tag=v1.1"
+    res_url, res_params = test_module.split_url_params(url)
+    assert res_url == 'https://foo/bar'
+    assert res_params == {'tag': ['v1.1']}


### PR DESCRIPTION
Allow lazy initializing and instantiating linked resources that contain a tag. For example:

```json
  "brainTemplateDataLayer": {
    "@id": "https://bbp.epfl.ch/neurosciencegraph/data/dca40f99-b494-4d2c-9a2f-c407180138b7",
    "@type": "BrainTemplateDataLayer",
    "tag": "v1.1.0"
  },
```
A `_tag` attribute is added in Identifiable which allows to store the tag for each entity.