### PR TITLE
Add BrainAtlasRelease entity

### DIFF
--- a/entity_management/atlas.py
+++ b/entity_management/atlas.py
@@ -175,6 +175,10 @@ class AtlasRelease(Entity):
     """AtlasRelease resource representation."""
 
 
+class BrainAtlasRelease(AtlasRelease):
+    """BrainAtlasRelease resource representation."""
+
+
 @attributes(
     {
         "atlasRelease": AttrOf(AtlasRelease, default=None),


### PR DESCRIPTION
Alias to AtlasRelease to ensure instantiation of both on AtlasRelease and BrainAtlasRelease types.