### PR TITLE
Make Derivation & BrainLocation blank nodes

### DIFF
--- a/entity_management/base.py
+++ b/entity_management/base.py
@@ -459,7 +459,7 @@ def _deserialize_frozen(data_type, data_raw, context, base, org, proj, token):
             # These resources need to have a @type but it is not yet present in their data. To allow
             # backward compatibity the data type's name is used when type is not found.
             # If all the BlankNode resources have been updated with a @type, this can be removed.
-            data._force_attr("_type", data_type.__name__)
+            L.warning("No @type found in BlankNode data. The class type will be used instead.")
     return data
 
 

--- a/entity_management/base.py
+++ b/entity_management/base.py
@@ -452,7 +452,14 @@ def _deserialize_frozen(data_type, data_raw, context, base, org, proj, token):
     data = data_type(**field_values)
 
     if issubclass(data_type, BlankNode):
-        data._force_attr("_type", data_raw[JSLD_TYPE])
+        try:
+            data._force_attr("_type", data_raw[JSLD_TYPE])
+        except KeyError:
+            # This is a workaround for entities that need to be migrated from Frozen to BlankNode
+            # These resources need to have a @type but it is not yet present in their data. To allow
+            # backward compatibity the data type's name is used when type is not found.
+            # If all the BlankNode resources have been updated with a @type, this can be removed.
+            data._force_attr("_type", data_type.__name__)
     return data
 
 
@@ -895,7 +902,7 @@ class OntologyTerm(Frozen):
 
 
 @attributes({"brainRegion": AttrOf(OntologyTerm)})
-class BrainLocation(Frozen):
+class BrainLocation(BlankNode):
     """Brain location.
 
     Args:
@@ -908,7 +915,7 @@ class BrainLocation(Frozen):
         "entity": AttrOf(Identifiable),
     }
 )
-class Derivation(Frozen):
+class Derivation(BlankNode):
     """Derivation."""
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -21,6 +21,7 @@ from entity_management.base import (
     Identifiable,
     OntologyTerm,
     _deserialize_list,
+    _deserialize_frozen,
     _deserialize_json_to_datatype,
     _serialize_obj,
     Unconstrained,
@@ -322,6 +323,12 @@ def _eval(string_or_type):
 )
 def test_deserialize_json_to_datatype(data_type, data_raw, expected):
     assert _deserialize_json_to_datatype(_eval(data_type), data_raw) == expected
+
+
+def test_deserialize_frozen():
+    # test that a frozen deserialized as BlankNode works for backward compatibility
+    res = _deserialize_frozen(BlankNode1, {"a": 2, "b": 3.0}, None, None, None, None, None)
+    assert res == BlankNode1(a=2, b=3.0)
 
 
 def _make_valid_resp(data):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -30,6 +30,8 @@ from entity_management.base import (
     attributes,
     AttrOf,
     Subject,
+    Derivation,
+    BrainLocation,
 )
 from entity_management import state
 from entity_management.state import get_org, get_proj
@@ -87,6 +89,38 @@ def test_serialize():
     assert _serialize_obj(dummy) == {"a": {1: 2}, "b": [{"@id": "A", "label": "B"}]}
 
     assert _serialize_obj(42) == 42
+
+
+def test_serialize__derivation():
+
+    @attributes(
+        {
+            "a": AttrOf(int),
+            "b": AttrOf(float),
+        }
+    )
+    class A(Identifiable):
+        pass
+
+    resp = _make_valid_resp({"@id": "my-id", "@type": "A", "a": 1, "b": 2.0})
+
+    with patch("entity_management.nexus.load_by_id", return_value=resp):
+        a = A.from_id("my-id")
+
+    derivation = Derivation(entity=a)
+
+    res = _serialize_obj(derivation)
+
+    assert res == {"entity": {"@id": "my-id", "@type": "A"}, "@type": "Derivation"}
+
+
+def test_serialize__brain_location():
+
+    brain_location = BrainLocation(brainRegion=OntologyTerm(url="foo"))
+
+    res = _serialize_obj(brain_location)
+
+    assert res == {"brainRegion": {"@id": "foo", "label": None}, "@type": "BrainLocation"}
 
 
 def test_serialize_obj__include_rev__instantiated_with_revision():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,7 @@ import pytest
 
 import entity_management.nexus as nexus
 from entity_management.core import DataDownload, WorkflowExecution, Entity, Activity, Person
+from entity_management import core as test_module
 
 
 @pytest.fixture(name="workflow_resp", scope="session")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,6 @@ import pytest
 
 import entity_management.nexus as nexus
 from entity_management.core import DataDownload, WorkflowExecution, Entity, Activity, Person
-from entity_management import core as test_module
 
 
 @pytest.fixture(name="workflow_resp", scope="session")


### PR DESCRIPTION
Both Derivation and BrainLocation shape validation requires a class `@type` to pass validation:

https://bbpgitlab.epfl.ch/dke/apps/brain-modeling-ontology/-/blob/develop/shapes/commons/entitywithoutannotationsubject.json?ref_type=heads#L131
https://bbpgitlab.epfl.ch/dke/apps/brain-modeling-ontology/-/blob/develop/shapes/commons/entitywithoutannotationsubject.json?ref_type=heads#L206

This change is backwards compatible with older resources that are still Frozen, using the class type as `@type` where missing.