### PR TITLE
Ensure include_rev works recursively for identifiables

### DIFF
--- a/entity_management/base.py
+++ b/entity_management/base.py
@@ -231,11 +231,13 @@ def _serialize_obj(value, include_rev=False):
             attr_value = getattr(value, attr_name)
             if attr_value is not None:  # ignore empty values
                 if isinstance(attr_value, (tuple, list, set)):
-                    rv[attr_name] = [_serialize_obj(i) for i in attr_value]
+                    rv[attr_name] = [_serialize_obj(i, include_rev) for i in attr_value]
                 elif isinstance(attr_value, dict):
-                    rv[attr_name] = {kk: _serialize_obj(vv) for kk, vv in attr_value.items()}
+                    rv[attr_name] = {
+                        kk: _serialize_obj(vv, include_rev) for kk, vv in attr_value.items()
+                    }
                 else:
-                    rv[attr_name] = _serialize_obj(attr_value)
+                    rv[attr_name] = _serialize_obj(attr_value, include_rev)
         if hasattr(value, "_type"):  # BlankNode have types
             rv[JSLD_TYPE] = value._type
         return rv

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -137,6 +137,13 @@ def test_serialize_obj__include_rev__instantiated_with_revision():
     res = _serialize_obj(a, include_rev=True)
     assert res == {JSLD_ID: "foo", JSLD_TYPE: "A", JSLD_LINK_REV: 5}
 
+    d = Derivation(entity=a)
+    res = _serialize_obj(d, include_rev=True)
+    assert res == {
+        "entity": {JSLD_ID: "foo", JSLD_TYPE: "A", JSLD_LINK_REV: 5},
+        JSLD_TYPE: "Derivation",
+    }
+
 
 def test_serialize_obj__include_rev__instantiated_wout_revision(monkeypatch):
 


### PR DESCRIPTION
```python
Entity(
    derivation=Derivation(entity=MyIdentifiable())
).publish(include_rev=True)
```
failed to include a `_rev` for the entity within the derivation.

This PR ensures revision inclusion works for all identifiables in the jsonld.