### PR TITLE
Add elasticsearch nexus endpoint and query function

### DIFF
--- a/entity_management/nexus.py
+++ b/entity_management/nexus.py
@@ -17,6 +17,7 @@ from entity_management.settings import DASH, JSLD_TYPE, NSG, USERINFO
 from entity_management.state import (
     get_base_files,
     get_base_url,
+    get_es_url,
     get_org,
     get_proj,
     get_sparql_url,
@@ -582,3 +583,30 @@ def sparql_query(query, base=None, org=None, proj=None, token=None):
     endpoint.setQuery(query)
     result = endpoint.query()
     return result._convertJSON()
+
+
+@_nexus_wrapper
+def es_query(query, base=None, org=None, proj=None, token=None):
+    """Execute Elasticsearch query.
+
+    Args:
+        query (dict): Elasticsearch dictionary query to serialize to json.
+        base (str): Nexus instance base url.
+        org (str): Nexus organization.
+        proj (str): Nexus project.
+        token (str): Optional OAuth token.
+
+    Returns:
+        Json response.
+    """
+    base_url = get_es_url(base, org, proj)
+
+    response = requests.post(
+        url=base_url,
+        headers=_get_headers(token, accept="application/json"),
+        json=query,
+        timeout=10,
+    )
+
+    response.raise_for_status()
+    return _to_json(response, query)

--- a/entity_management/state.py
+++ b/entity_management/state.py
@@ -176,6 +176,11 @@ def get_sparql_url(base=None, org=None, proj=None):
     return f"{get_base_views(base)}/{get_org(org)}/{get_proj(proj)}/graph/sparql"
 
 
+def get_es_url(base=None, org=None, proj=None):
+    """Get base elasticsearch url."""
+    return f"{get_base_views(base)}/{get_org(org)}/{get_proj(proj)}/documents/_search"
+
+
 def get_base_files(base=None):
     """Get url to nexus environment base for the files.
 

--- a/tests/test_nexus.py
+++ b/tests/test_nexus.py
@@ -180,3 +180,37 @@ def test_load_by_id__with_tag():
             stream=False,
             token=None,
         )
+
+
+@responses.activate
+def test_es_query():
+
+    json_response = {
+        "hits": {
+            "hits": [
+                {
+                    "_id": "https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/488e70c6-7163-414b-9e91-cae58bad9545",
+                    "_index": "nexus_ac626f52-a548-439a-9b4d-913304323ffe_1",
+                    "_score": 10.913751,
+                },
+            ],
+            "max_score": 10.913751,
+            "total": {"relation": "eq", "value": 1},
+        },
+        "timed_out": False,
+        "took": 1,
+        "_shards": {"failed": 0, "skipped": 0, "successful": 1, "total": 1},
+    }
+
+    responses.add(
+        responses.POST,
+        "https://foo/views/bar/zee/documents/_search",
+        json=json_response,
+        content_type="application/json",
+    )
+
+    query = {"query": {"term": {"@type": "Foo"}}}
+
+    res = nexus.es_query(query, base="https://foo", org="bar", proj="zee")
+
+    assert res == json_response

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -58,4 +58,4 @@ def test_get_es_url():
         with patch("entity_management.state.PROJ", "my-proj"):
             with patch("entity_management.state.ORG", "my-org"):
                 res = test_module.get_es_url()
-                assert res == "my-base/views/my-proj/my-org/documents/_search"
+                assert res == "my-base/views/my-org/my-proj/documents/_search"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -47,3 +47,15 @@ def test_get_user_id():
         with patch("entity_management.state.ORG", "my-org"):
             res = test_module.get_user_id(base="base")
             assert res == "base/realms/my-org/users/foo"
+
+
+def test_get_es_url():
+
+    res = test_module.get_es_url(base="foo", org="bar", proj="zee")
+    assert res == "foo/views/bar/zee/documents/_search"
+
+    with patch("entity_management.state.BASE", "my-base"):
+        with patch("entity_management.state.PROJ", "my-proj"):
+            with patch("entity_management.state.ORG", "my-org"):
+                res = test_module.get_es_url()
+                assert res == "foo/views/bar/zee/documents/_search"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -58,4 +58,4 @@ def test_get_es_url():
         with patch("entity_management.state.PROJ", "my-proj"):
             with patch("entity_management.state.ORG", "my-org"):
                 res = test_module.get_es_url()
-                assert res == "foo/views/bar/zee/documents/_search"
+                assert res == "my-base/views/my-proj/my-org/documents/_search"


### PR DESCRIPTION
Example usage:
```python
from entity_management.nexus import es_query

query = {
  "_source": False,
  "query": {
    "bool": {
      "must": [
        {
          "term": {
            "@type": "https://bbp.epfl.ch/ontologies/core/bmo/Variant"
          }
        },
        {
          "term": {
            "_deprecated": False
          }
        }
      ]
    }
  }
}

result = es_query(query)
```
And the result will be something like:
```
{'hits': {'hits': [{'_id': 'https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/488e70c6-7163-414b-9e91-cae58bad9545',
    '_index': 'nexus_ac626f52-a548-439a-9b4d-913304323ffe_1',
    '_score': 10.913751},
   {'_id': 'https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/7e33ae4a-9ae1-4248-86f3-5ce65a9d7b70',
    '_index': 'nexus_ac626f52-a548-439a-9b4d-913304323ffe_1',
    '_score': 10.913751},
   {'_id': 'https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/ec695d50-a9b3-4bc7-a58c-7780ed44b9e6',
    '_index': 'nexus_ac626f52-a548-439a-9b4d-913304323ffe_1',
    '_score': 10.913751},
   {'_id': 'https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/0b3d0754-dc50-4ee0-ab22-0ca66e0fa677',
    '_index': 'nexus_ac626f52-a548-439a-9b4d-913304323ffe_1',
    '_score': 10.913751},
   {'_id': 'https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/c29f3f59-23ef-4c39-9afe-845291937840',
    '_index': 'nexus_ac626f52-a548-439a-9b4d-913304323ffe_1',
    '_score': 10.913751}],
  'max_score': 10.913751,
  'total': {'relation': 'eq', 'value': 31}},
 'timed_out': False,
 'took': 1,
 '_shards': {'failed': 0, 'skipped': 0, 'successful': 1, 'total': 1}}

```