### PR TITLE
Remove log color formatting

### DIFF
--- a/entity_management/debug.py
+++ b/entity_management/debug.py
@@ -1,0 +1,49 @@
+"""Debug utilities."""
+
+import os
+import sys
+from functools import partial
+from typing import Optional
+
+
+def _env_true(var_name: str) -> Optional[bool]:
+    """Return True, False, or None depending on the value of the given env variable name.
+
+    Return:
+
+    - True if the env variable is set to "1" or "true" (case-insensitive)
+    - None if it's set to an empty string, or not set
+    - False if it's set to something else
+    """
+    env = os.getenv(var_name, None)
+    return env.upper() in {"1", "TRUE"} if env else None
+
+
+def _get_pformat():
+    """Return the function to be used for formatting."""
+    if _env_true("PY_DEVTOOLS_ENABLE"):
+        from devtools import pformat  # pylint: disable=import-error,import-outside-toplevel
+
+        force_highlight = _env_true("PY_DEVTOOLS_HIGHLIGHT")
+        highlight = sys.stdout.isatty() if force_highlight is None else force_highlight
+        return partial(pformat, highlight=highlight)
+    return str
+
+
+class PP:
+    """Lazy pretty printer with pformat from devtools, or fallback to str.
+
+    To enable devtools pretty formatting:
+
+    - ensure that devtools is installed
+    - set PY_DEVTOOLS_ENABLE=1
+    - set PY_DEVTOOLS_HIGHLIGHT=1
+    """
+
+    _pformat = staticmethod(_get_pformat())
+
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self):
+        return self._pformat(self.value)

--- a/entity_management/nexus.py
+++ b/entity_management/nexus.py
@@ -13,6 +13,7 @@ from functools import wraps
 import requests
 from SPARQLWrapper import JSON, POST, POSTDIRECTLY, SPARQLWrapper
 
+from entity_management.debug import PP
 from entity_management.settings import DASH, JSLD_TYPE, NSG, USERINFO
 from entity_management.state import (
     get_base_files,
@@ -93,11 +94,11 @@ def _print_nexus_error(http_error):
         response_data = response.text
     L.error(
         "Nexus error!\nmethod = %s\nurl = %s\npayload = %s\nstatus = %s\nresponse = %s",
-        request.method,
-        request.url,
-        request_data,
-        response.status_code,
-        response_data,
+        PP(request.method),
+        PP(request.url),
+        PP(request_data),
+        PP(response.status_code),
+        PP(response_data),
     )
 
 
@@ -106,10 +107,10 @@ def _to_json(response, payload=None):
     json = response.json()
     L.debug(
         "Nexus request\nmethod = %s\nurl = %s\npayload = %s\nresponse = %s",
-        response.request.method,
-        response.request.url,
-        payload,
-        json,
+        PP(response.request.method),
+        PP(response.request.url),
+        PP(payload),
+        PP(json),
     )
     return json
 
@@ -514,8 +515,8 @@ def download_file(url, path, file_name=None, tag=None, rev=None, token=None):
         response.raise_for_status()
         L.debug(
             "Nexus request\nmethod = %s\nurl = %s",
-            response.request.method,
-            response.request.url,
+            PP(response.request.method),
+            PP(response.request.url),
         )
         if file_name is None:
             content_disposition = response.headers.get("content-disposition")

--- a/entity_management/nexus.py
+++ b/entity_management/nexus.py
@@ -24,7 +24,7 @@ from entity_management.state import (
     has_offline_token,
     refresh_token,
 )
-from entity_management.util import PP, quote, split_url_params, unquote_uri_path
+from entity_management.util import quote, split_url_params, unquote_uri_path
 
 L = logging.getLogger(__name__)
 
@@ -93,11 +93,11 @@ def _print_nexus_error(http_error):
         response_data = response.text
     L.error(
         "Nexus error!\nmethod = %s\nurl = %s\npayload = %s\nstatus = %s\nresponse = %s",
-        PP(request.method),
-        PP(request.url),
-        PP(request_data),
-        PP(response.status_code),
-        PP(response_data),
+        request.method,
+        request.url,
+        request_data,
+        response.status_code,
+        response_data,
     )
 
 
@@ -106,10 +106,10 @@ def _to_json(response, payload=None):
     json = response.json()
     L.debug(
         "Nexus request\nmethod = %s\nurl = %s\npayload = %s\nresponse = %s",
-        PP(response.request.method),
-        PP(response.request.url),
-        PP(payload),
-        PP(json),
+        response.request.method,
+        response.request.url,
+        payload,
+        json,
     )
     return json
 
@@ -514,8 +514,8 @@ def download_file(url, path, file_name=None, tag=None, rev=None, token=None):
         response.raise_for_status()
         L.debug(
             "Nexus request\nmethod = %s\nurl = %s",
-            PP(response.request.method),
-            PP(response.request.url),
+            response.request.method,
+            response.request.url,
         )
         if file_name is None:
             content_disposition = response.headers.get("content-disposition")

--- a/entity_management/util.py
+++ b/entity_management/util.py
@@ -11,7 +11,6 @@ from urllib.parse import unquote, urlparse
 import attr
 from attr.validators import instance_of as instance_of_validator
 from attr.validators import optional as optional_validator
-from devtools import pformat
 
 from entity_management import state, typecheck
 from entity_management.exception import EntityNotInstantiatedError, ResourceNotFoundError
@@ -200,17 +199,6 @@ def split_url_params(url):
     url = f"{res.scheme}://{res.netloc}{res.path}"
     params = parse_qs(res.query)
     return url, params
-
-
-class PP:
-    """Lazy pretty printer with pformat from devtools."""
-
-    def __init__(self, value, highlight=True):
-        self.value = value
-        self.highlight = highlight
-
-    def __str__(self):
-        return pformat(self.value, highlight=self.highlight)
 
 
 def unquote_uri_path(uri):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
   "rdflib",
   "pyjwt",
   "python-keycloak",
-  "devtools[pygments]",
   "click",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Remove color formatting of logs because it makes difficult to read logs when using non plain formatting (for example with structured logs formatted as json)