### PR TITLE
Patch breaking EModel loading

### DIFF
--- a/entity_management/emodel.py
+++ b/entity_management/emodel.py
@@ -28,13 +28,13 @@ from entity_management.util import AttrOf
         "prefLabel": AttrOf(str, default=None),
     }
 )
-class MTypeAnnotationBody(BlankNode):
-    """MTypeAnnotationBody."""
+class AnnotationBody(BlankNode):
+    """AnnotationBody."""
 
 
 @attributes(
     {
-        "hasBody": AttrOf(MTypeAnnotationBody),
+        "hasBody": AttrOf(AnnotationBody),
         "name": AttrOf(str, default=None),
     }
 )
@@ -44,22 +44,22 @@ class MTypeAnnotation(BlankNode):
 
 @attributes(
     {
-        "label": AttrOf(str),
-        "prefLabel": AttrOf(str, default=None),
-    }
-)
-class ETypeAnnotationBody(BlankNode):
-    """ETypeAnnotationBody."""
-
-
-@attributes(
-    {
-        "hasBody": AttrOf(ETypeAnnotationBody),
+        "hasBody": AttrOf(AnnotationBody),
         "name": AttrOf(str, default=None),
     }
 )
 class ETypeAnnotation(BlankNode):
     """ETypeAnnotation."""
+
+
+@attributes(
+    {
+        "hasBody": AttrOf(dict),
+        "name": AttrOf(str, default=None),
+    }
+)
+class QualityAnnotation(BlankNode):
+    """QualityAnnotation."""
 
 
 @attributes(
@@ -74,7 +74,9 @@ class ETypeAnnotation(BlankNode):
         "brainLocation": AttrOf(BrainLocation, default=None),
         "atlasRelease": AttrOf(AtlasRelease, default=None),
         "subject": AttrOf(Subject, default=None),
-        "annotation": AttrOf(List[Union[MTypeAnnotation, ETypeAnnotation]], default=None),
+        "annotation": AttrOf(
+            List[Union[MTypeAnnotation, ETypeAnnotation, QualityAnnotation]], default=None
+        ),
     }
 )
 class EModelEntity(MultiDistributionEntity):

--- a/tests/data/emodel_resp.json
+++ b/tests/data/emodel_resp.json
@@ -36,6 +36,26 @@
         "label": "L6_LBC"
       },
       "name": "M-type annotation"
+    },
+    {
+      "@type": [
+        "QualityAnnotation",
+        "Annotation"
+      ],
+      "hasBody": {
+        "@id": "https://bbp.epfl.ch/ontologies/core/bmo/AnalysisSuitable",
+        "@type": [
+          "AnnotationBody",
+          "DataScope"
+        ],
+        "label": "Analysis Suitable"
+      },
+      "motivatedBy": {
+        "@id": "quality:Assessment",
+        "@type": "Motivation"
+      },
+      "name": "Data usage scope annotation",
+      "note": "Analysis can be run on this model."
     }
   ],
   "atlasRelease": {

--- a/tests/test_emodel.py
+++ b/tests/test_emodel.py
@@ -61,7 +61,10 @@ def _has_agent_id(obj):
 
 
 def _has_body_label(obj):
-    assert all(_apply(lambda o: o.hasBody.label is not None, obj))
+    without_quality_annotation = [
+        o for o in obj if not isinstance(o, test_module.QualityAnnotation)
+    ]
+    assert all(_apply(lambda o: o.hasBody.label is not None, without_quality_annotation))
 
 
 def _nonempty_list(obj):


### PR DESCRIPTION
The new QualityAnnotation annotation property is breaking existing EModel loading.

This PR patches this issue by simply defining a QualityAnnotation that has a dict hasBody for now.