### PR TITLE
Remove Generation from Entity.

### DIFF
--- a/entity_management/core.py
+++ b/entity_management/core.py
@@ -448,15 +448,6 @@ class Contribution(BlankNode):
 
 @attributes(
     {
-        "activity": AttrOf(Activity),
-    }
-)
-class Generation(BlankNode):
-    """Generation."""
-
-
-@attributes(
-    {
         "name": AttrOf(str, default=None),
         "description": AttrOf(str, default=None),
         "wasAttributedTo": AttrOf(List[Agent], default=None),
@@ -465,7 +456,6 @@ class Generation(BlankNode):
         "dateCreated": AttrOf(datetime, default=None),
         "distribution": AttrOf(MaybeList[DataDownload], default=None),
         "contribution": AttrOf(List[Contribution], default=None),
-        "generation": AttrOf(List[Generation], default=None),
     }
 )
 class Entity(Identifiable):


### PR DESCRIPTION
Given that we do not support dual representation of entities that can be both Frozen or Identifiable, having the Generation that expects an Identifiable Activity breaks deserialization when Entity is instantiated with a resource with a Frozen Activity.

For this reason, it is better not to have Generation at the Entity level and let the specific types handle the layout of their Generation shapes.