### PR TITLE
Add lazy schema validator for distribution json data

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-disable=fixme,invalid-name,len-as-condition,no-else-return,protected-access
+disable=fixme,invalid-name,len-as-condition,no-else-return,protected-access, too-many-positional-arguments
 
 [FORMAT]
 # Maximum number of characters on a single line.

--- a/entity_management/config.py
+++ b/entity_management/config.py
@@ -8,8 +8,8 @@
 """
 
 from entity_management.base import Frozen, _NexusBySparqlIterator, attributes
-from entity_management.core import Entity
-from entity_management.util import AttrOf
+from entity_management.core import DataDownload, Entity
+from entity_management.util import AttrOf, LazySchemaValidator
 from entity_management.workflow import BbpWorkflowConfig, GeneratorTaskActivity
 
 
@@ -49,38 +49,110 @@ class _SubConfig(BbpWorkflowConfig):
         return self.distribution.as_dict()
 
 
+@attributes(
+    {
+        "distribution": AttrOf(
+            DataDownload,
+            validators=[LazySchemaValidator("brain_region_selector_config_distribution.yml")],
+        )
+    }
+)
 class BrainRegionSelectorConfig(_SubConfig):
     """BrainRegionSelectorConfig"""
 
 
+@attributes(
+    {
+        "distribution": AttrOf(
+            DataDownload,
+            validators=[LazySchemaValidator("cell_composition_config_distribution.yml")],
+        )
+    }
+)
 class CellCompositionConfig(_SubConfig):
     """CellCompositionConfig"""
 
 
+@attributes(
+    {
+        "distribution": AttrOf(
+            DataDownload,
+            validators=[LazySchemaValidator("cell_position_config_distribution.yml")],
+        )
+    }
+)
 class CellPositionConfig(_SubConfig):
     """CellPositionConfig"""
 
 
+@attributes(
+    {
+        "distribution": AttrOf(
+            DataDownload,
+            validators=[LazySchemaValidator("emodel_assignment_config_distribution.yml")],
+        )
+    }
+)
 class EModelAssignmentConfig(_SubConfig):
     """EModelAssignmentConfig"""
 
 
+@attributes(
+    {
+        "distribution": AttrOf(
+            DataDownload,
+            validators=[LazySchemaValidator("macro_connectome_config_distribution.yml")],
+        )
+    }
+)
 class MacroConnectomeConfig(_SubConfig):
     """MacroConnectomeConfig"""
 
 
+@attributes(
+    {
+        "distribution": AttrOf(
+            DataDownload,
+            validators=[LazySchemaValidator("micro_connectome_config_distribution.yml")],
+        )
+    }
+)
 class MicroConnectomeConfig(_SubConfig):
     """MicroConnectomeConfig"""
 
 
+@attributes(
+    {
+        "distribution": AttrOf(
+            DataDownload,
+            validators=[LazySchemaValidator("morphology_assignment_config_distribution.yml")],
+        )
+    }
+)
 class MorphologyAssignmentConfig(_SubConfig):
     """MorphologyAssignmentConfig"""
 
 
+@attributes(
+    {
+        "distribution": AttrOf(
+            DataDownload,
+            validators=[LazySchemaValidator("synapse_config_distribution.yml")],
+        )
+    }
+)
 class SynapseConfig(_SubConfig):
     """SynapseConfig"""
 
 
+@attributes(
+    {
+        "distribution": AttrOf(
+            DataDownload,
+            validators=[LazySchemaValidator("me_model_config_distribution.yml")],
+        )
+    }
+)
 class MEModelConfig(_SubConfig):
     """MEModelConfig"""
 

--- a/entity_management/config.py
+++ b/entity_management/config.py
@@ -89,7 +89,6 @@ class CellPositionConfig(_SubConfig):
     {
         "distribution": AttrOf(
             DataDownload,
-            validators=[LazySchemaValidator("emodel_assignment_config_distribution.yml")],
         )
     }
 )

--- a/entity_management/exception.py
+++ b/entity_management/exception.py
@@ -13,3 +13,7 @@ class ResourceNotFoundError(EntityManagementError):
 
 class EntityNotInstantiatedError(EntityManagementError):
     """Error related to entities failing to be instantiated."""
+
+
+class SchemaValidationError(EntityManagementError):
+    """Schema validation exception class."""

--- a/entity_management/schemas/brain_region_selector_config_distribution.yml
+++ b/entity_management/schemas/brain_region_selector_config_distribution.yml
@@ -1,0 +1,27 @@
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: BrainRegionSelectorConfig distribution schema
+'$defs':
+  selection_entry:
+    type: object
+    required:
+      - '@id'
+      - 'notation'
+      - 'label'
+    properties:
+      '@id':
+        type: string
+        # brain region finishing in /Structure/int
+        pattern: '^https?:\/\/.*\/Structure\/\d*$'
+      notation:
+        type: string
+      label:
+        type: string
+type: object
+required:
+  - selection
+properties:
+  selection:
+    type: array
+    items:
+      type: object
+      '$ref': '#/$defs/selection_entry'

--- a/entity_management/schemas/cell_composition_config_distribution.yml
+++ b/entity_management/schemas/cell_composition_config_distribution.yml
@@ -1,0 +1,99 @@
+%YAML 1.1
+---
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: CellCompositionConfig distribution schema
+
+'$defs':
+  uri:
+    type: string
+    format: uri
+    pattern: '^https?:\/\/[^?#]*$'  # uri without query or fragment
+
+  revision:
+    type: integer
+    minimum: 1
+
+  variant_info:
+    type: object
+    required:
+      - algorithm
+      - version
+    algorithm:
+      type: string
+    version:
+      type: string
+
+  input_entry:
+    type: object
+    required:
+      - name
+      - type
+      - id
+    properties:
+      name:
+        type: string
+      type:
+        type: string
+      id:
+        type: string
+
+additionalProperties: false
+patternProperties:
+  '^http://api.brain-map.org/api/v2/data/Structure/997$':
+    type: object
+    required:
+      - variantDefinition
+      - inputs
+      - configuration
+
+    additionalProperties: false
+    properties:
+
+      variantDefinition:
+        '$ref': '#/$defs/variant_info'
+
+      inputs:
+        type: array
+        items:
+          '$ref': '#/$defs/input_entry'
+
+      configuration:
+        type: object
+        required:
+          - overrides
+        properties:
+          overrides:
+            additionalProperties: false
+            patternProperties:
+              '^https?:\/\/.*\/Structure\/\d*$':  # brain regions finishing in /Structure/int
+                type: object
+                required:
+                  - label
+                  - hasPart
+                properties:
+                  label:
+                    type: string
+                  hasPart:
+                    type: object
+                    additionalProperties: false
+                    patternProperties:
+                      '^https?:\/\/[^?#]*$':  # etypes
+                        type: object
+                        properties:
+                          label:
+                            type: string
+                          '_rev':
+                            type: integer
+                          composition:
+                            type: object
+                            required:
+                              - neuron
+                            properties:
+                              neuron:
+                                type: object
+                                required:
+                                  - density
+                                properties:
+                                  density:
+                                    type: number
+

--- a/entity_management/schemas/cell_position_config_distribution.yml
+++ b/entity_management/schemas/cell_position_config_distribution.yml
@@ -1,0 +1,40 @@
+%YAML 1.1
+---
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: CellCompositionConfig distribution schema
+
+'$defs':
+  variant_info:
+    type: object
+    required:
+      - algorithm
+      - version
+    algorithm:
+      type: string
+    version:
+      type: string
+
+additionalProperties: false
+patternProperties:
+  '^http://api.brain-map.org/api/v2/data/Structure/997$':
+    type: object
+    required:
+      - variantDefinition
+      - configuration
+    properties:
+      variantDefinition:
+        '$ref': '#/$defs/variant_info'
+      configuration:
+        type: object
+        required:
+          - place_cells
+        properties:
+          place_cells:
+            type: object
+            properties:
+              soma_placement:
+                type: string
+              density_factor:
+                type: number
+              seed:
+                type: integer

--- a/entity_management/schemas/macro_connectome_config_distribution.yml
+++ b/entity_management/schemas/macro_connectome_config_distribution.yml
@@ -1,0 +1,60 @@
+%YAML 1.1
+---
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: MacroConnectomeConfig distribution schema
+
+'$defs':
+
+  uri:
+    type: string
+    format: uri
+    pattern: '^https?:\/\/[^?#]*$'  # uri without query or fragment
+
+  revision:
+    type: integer
+    minimum: 1
+
+
+required:
+  - initial
+
+properties:
+
+  initial:
+    type: object
+    properties:
+      connection_strength:
+        type: object
+        additionalProperties: false
+        properties:
+          id:
+            '$ref': '#/$defs/uri'
+          type:
+            'oneOf':
+              - type: string
+                const: BrainConnectomeStrength
+              - type: array
+                contains:
+                  type: string
+                  const: BrainConnectomeStrength
+          rev:
+            '$ref': '#/$defs/revision'
+  overrides:
+    type: object
+    properties:
+      connection_strength:
+        type: object
+        additionalProperties: false
+        properties:
+          id:
+            '$ref': '#/$defs/uri'
+          type:
+            'oneOf':
+              - type: string
+                const: BrainConnectomeStrengthOverrides
+              - type: array
+                contains:
+                  type: string
+                  const: BrainConnectomeStrengthOverrides
+          rev:
+            '$ref': '#/$defs/revision'

--- a/entity_management/schemas/me_model_config_distribution.yml
+++ b/entity_management/schemas/me_model_config_distribution.yml
@@ -1,0 +1,82 @@
+%YAML 1.1
+---
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: MorphologyAssignmentConfig distribution schema
+'$defs':
+  uri:
+    type: string
+    format: uri
+    pattern: '^https?:\/\/[^?#]*$'  # uri without query or fragment
+  revision:
+    type: integer
+    minimum: 1
+  variant_info:
+    type: object
+    required:
+      - algorithm
+      - version
+    algorithm:
+      type: string
+    version:
+      type: string
+  entity_entry:
+      type: object
+      required:
+        - '@id'
+      properties:
+        '@id':
+          '$ref': '#/$defs/uri'
+        '_rev':
+          '$ref': '#/$defs/revision'
+type: object
+required:
+  - variantDefinition
+  - defaults
+properties:
+
+  version:
+    type: integer
+    minimim: 1
+
+  variantDefinition:
+    type: object
+    properties:
+      neurons_me_model:
+        "$ref": "#/$defs/variant_info"
+
+  defaults:
+    type: object
+    properties:
+      neurons_me_model:
+        "$ref": "#/$defs/entity_entry"
+
+  overrides:
+    type: object
+    properties:
+      neurons_me_model:
+        type: object
+        patternProperties:
+          '^https?:\/\/.*\/Structure\/\d*$':  # brain regions finishing in /Structure/int
+            type: object
+            patternProperties:
+              '^https?:\/\/[^?#]*$':  # mtypes
+                type: object
+                patternProperties:
+                  '^https?:\/\/[^?#]*$':  # etypes
+                    type: object
+                    properties:
+                      assignmentAlgorithm:
+                        const: "assignOne"
+                      eModel:
+                        "$ref": "#/$defs/entity_entry"
+                      axonInitialSegmentAssignment:
+                        type: object
+                        properties:
+                          fixedValue:
+                            type: object
+                            properties:
+                              value:
+                                type: number
+                            additionalProperties: false
+                        additionalProperties: false
+                      additionalProperties: false

--- a/entity_management/schemas/micro_connectome_config_distribution.yml
+++ b/entity_management/schemas/micro_connectome_config_distribution.yml
@@ -1,0 +1,220 @@
+%YAML 1.1
+---
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: MicroConnectomeConfig distribution schema
+
+'$defs':
+
+  uri:
+    type: string
+    format: uri
+    pattern: '^https?:\/\/[^?#]*$'  # uri without query or fragment
+
+  revision:
+    type: integer
+    minimum: 1
+
+  param:
+    type: object
+    additionalProperties: false
+    properties:
+      type:
+        type: string
+      unitCode:
+        type: string
+      default:
+        type: number
+
+
+type: object
+
+required:
+  - variants
+  - initial
+  - overrides
+
+properties:
+
+  variants:
+    type: object
+    properties:
+      placeholder__erdos_renyi:
+        type: object
+        additionalProperties: false
+        properties:
+          algorithm:
+            type: string
+          version:
+            type: string
+          params:
+            type: object
+            properties:
+              weight:
+                '$ref': '#/$defs/param'
+              nsynconn_mean:
+                '$ref': '#/$defs/param'
+              nsynconn_std:
+                '$ref': '#/$defs/param'
+              delay_velocity:
+                '$ref': '#/$defs/param'
+              delay_offset:
+                '$ref': '#/$defs/param'
+      placeholder__distance_dependent:
+        type: object
+        additionalProperties: false
+        properties:
+          algorithm:
+            type: string
+          version:
+            type: string
+          params:
+            type: object
+            properties:
+              weight:
+                '$ref': '#/$defs/param'
+              exponent:
+                '$ref': '#/$defs/param'
+              nsynconn_mean:
+                '$ref': '#/$defs/param'
+              nsynconn_std:
+                '$ref': '#/$defs/param'
+              delay_velocity:
+                '$ref': '#/$defs/param'
+              delay_offset:
+                '$ref': '#/$defs/param'
+    initial:
+      type: object
+      additionalProperties: false
+      required:
+        - variants
+        - placeholder__erdos_renyi
+        - placeholder__distance_dependent
+      properties:
+        variants:
+          type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              '$ref': '#/$defs/uri'
+            type:
+              'oneOf':
+                - type: string
+                  const: MicroConnectomeVariantSelection
+                - type: array
+                  items:
+                    type: string
+                  contains:
+                    type: string
+                    const: MicroConnectomeVariantSelection
+            rev:
+              '$ref': '#/$defs/revision'
+        placeholder__erdos_renyi:
+          type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              '$ref': '#/$defs/uri'
+            type:
+              'oneOf':
+                - type: string
+                  const: MicroConnectomeData
+                - type: array
+                  items:
+                    type: string
+                  contains:
+                    type: string
+                    const: MicroConnectomeData
+            rev:
+              '$ref': '#/$defs/revision'
+        placeholder__distance_dependent:
+          type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              '$ref': '#/$defs/uri'
+            type:
+              'oneOf':
+                - type: string
+                  const: MicroConnectomeData
+                - type: array
+                  items:
+                    type: string
+                  contains:
+                    type: string
+                    const: MicroConnectomeData
+            rev:
+              '$ref': '#/$defs/revision'
+    overrides:
+      type: object
+      additionalProperties: false
+      required:
+        - variants
+        - placeholder__erdos_renyi
+        - placeholder__distance_dependent
+      properties:
+        variants:
+          type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              '$ref': '#/$defs/uri'
+            type:
+              'oneOf':
+                - type: string
+                  const: MicroConnectomeVariantSelectionOverrides
+                - type: array
+                  items:
+                    type: string
+                  contains:
+                    type: string
+                    const: MicroConnectomeVariantSelectionOverrides
+            rev:
+              '$ref': '#/$defs/revision'
+        placeholder__erdos_renyi:
+          type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              '$ref': '#/$defs/uri'
+            type:
+              'oneOf':
+                - type: string
+                  const: MicroConnectomeDataOverrides
+                - type: array
+                  items:
+                    type: string
+                  contains:
+                    type: string
+                    const: MicroConnectomeDataOverrides
+            rev:
+              '$ref': '#/$defs/revision'
+        placeholder__distance_dependent:
+          type: object
+          required:
+            - id
+            - type
+          properties:
+            id:
+              '$ref': '#/$defs/uri'
+            type:
+              'oneOf':
+                - type: string
+                  const: MicroConnectomeDataOverrides
+                - type: array
+                  items:
+                    type: string
+                  contains:
+                    type: string
+                    const: MicroConnectomeDataOverrides
+            rev:
+              '$ref': '#/$defs/revision'

--- a/entity_management/schemas/morphology_assignment_config_distribution.yml
+++ b/entity_management/schemas/morphology_assignment_config_distribution.yml
@@ -1,0 +1,103 @@
+%YAML 1.1
+---
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: MorphologyAssignmentConfig distribution schema
+'$defs':
+  uri:
+    type: string
+    format: uri
+    pattern: '^https?:\/\/[^?#]*$'  # uri without query or fragment
+  revision:
+    type: integer
+    minimum: 1
+  variant_info:
+    type: object
+    required:
+      - algorithm
+      - version
+    algorithm:
+      type: string
+    version:
+      type: string
+  variant_entry:
+      type: object
+      required:
+        - '@id'
+      properties:
+        '@id':
+          '$ref': '#/$defs/uri'
+        '_rev':
+          '$ref': '#/$defs/revision'
+type: object
+required:
+  - variantDefinition
+  - defaults
+  - configuration
+properties:
+
+  version:
+    type: integer
+
+  variantDefinition:
+    type: object
+    required:
+      - topological_synthesis
+      - placeholder_assignment
+    properties:
+      topological_synthesis:
+        "$ref": "#/$defs/variant_info"
+      placeholder_assignment:
+        "$ref": "#/$defs/variant_info"
+
+  defaults:
+    type: object
+    required:
+      - topological_synthesis
+      - placeholder_assignment
+    properties:
+      topological_synthesis:
+        "$ref": "#/$defs/variant_entry"
+      placeholder_assignment:
+        "$ref": "#/$defs/variant_entry"
+
+  configuration:
+    type: object
+    properties:
+      topological_synthesis:
+        type: object
+        patternProperties:
+          '^https?:\/\/.*\/Structure\/\d*$':  # brain regions finishing in /Structure/int
+            type: object
+            patternProperties:
+              '^https?:\/\/[^?#]*$':  # mtypes
+                type: object
+                properties:
+                  '@id':
+                    '$ref': '#/$defs/uri'
+                  '_rev':
+                    '$ref': '#/$defs/revision'
+                  overrides:
+                    type: object
+                    properties:
+                      apical_dendrite:
+                        type: object
+                        properties:
+                          randomness:
+                            type: number
+                          step_size:
+                            type: object
+                            properties:
+                              norm:
+                                type: object
+                                properties:
+                                  mean:
+                                    type: number
+                                  std:
+                                    type: number
+                                additionalProperties: false
+                            additionalProperties: false
+                          targeting:
+                            type: number
+                  additionalProperties: false
+            additionalProperties: false
+        additionalProperties: false

--- a/entity_management/schemas/synapse_config_distribution.yml
+++ b/entity_management/schemas/synapse_config_distribution.yml
@@ -1,0 +1,104 @@
+%YAML 1.1
+---
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: SynapseConfig distribution schema
+
+'$defs':
+  uri:
+    type: string
+    format: uri
+    pattern: '^https?:\/\/[^?#]*$'  # uri without query or fragment
+
+  revision:
+    type: integer
+    minimum: 1
+
+  variant_info:
+    type: object
+    required:
+      - algorithm
+      - version
+    algorithm:
+      type: string
+    version:
+      type: string
+
+  synaptic_parameter_assignment:
+    type: object
+    required:
+      - id
+      - type
+    properties:
+      id:
+        '$ref': '#/$defs/uri'
+      type:
+        'oneOf':
+          - type: string
+            const: SynapticParameterAssignment
+          - type: array
+            maxItems: 2
+            items:
+              type: string
+              enum:
+                - Dataset
+                - SynapticParameterAssignment
+      rev:
+        '$ref': '#/$defs/revision'
+
+  synaptic_parameter:
+    type: object
+    required:
+      - id
+      - type
+    properties:
+      id:
+        '$ref': '#/$defs/uri'
+      type:
+        'oneOf':
+          - type: string
+            const: SynapticParameter
+          - type: array
+            maxItems: 2
+            items:
+              type: string
+              enum:
+                - Dataset
+                - SynapticParameter
+      rev:
+        '$ref': '#/$defs/revision'
+
+type: object
+
+required:
+  - variantDefinition
+  - defaults
+  - configuration
+
+properties:
+
+  variantDefinition:
+    '$ref': '#/$defs/variant_info'
+
+  defaults:
+    type: object
+    required:
+      - synapse_properties
+      - synapses_classification
+    properties:
+      synapse_properties:
+        '$ref': '#/$defs/synaptic_parameter_assignment'
+      synapses_classification:
+        '$ref': '#/$defs/synaptic_parameter' 
+    additionalProperties: false
+
+  configuration:
+    type: object
+    required:
+      - synapse_properties
+      - synapses_classification
+    properties:
+      synapse_properties:
+        '$ref': '#/$defs/synaptic_parameter_assignment'
+      synapses_classification:
+        '$ref': '#/$defs/synaptic_parameter' 
+    additionalProperties: false

--- a/entity_management/util.py
+++ b/entity_management/util.py
@@ -348,7 +348,7 @@ def validate_schema(data: dict, schema_name: str) -> None:
     validator = cls(schema)
     errors = validator.iter_errors(data)
 
-    messages: list[str] = []
+    messages = []
     for error in errors:
         if error.context:
             messages.extend(map(_format_error, error.context))

--- a/entity_management/util.py
+++ b/entity_management/util.py
@@ -16,7 +16,11 @@ from attr.validators import instance_of as instance_of_validator
 from attr.validators import optional as optional_validator
 
 from entity_management import state, typecheck
-from entity_management.exception import EntityNotInstantiatedError, ResourceNotFoundError, SchemaValidationError
+from entity_management.exception import (
+    EntityNotInstantiatedError,
+    ResourceNotFoundError,
+    SchemaValidationError,
+)
 
 # copied from attrs, their standard way to make validators
 

--- a/entity_management/util.py
+++ b/entity_management/util.py
@@ -38,6 +38,14 @@ class LazySchemaValidator:
 
     schema = attr.ib()
 
+    @property
+    def _schema_path(self):
+        return resources.files(__package__) / "schemas" / self.schema
+
+    def __attrs_post_init__(self):
+        if not self._schema_path.exists():
+            raise FileNotFoundError(f"Schema {self.schema} not found.")
+
     def _lazy_schema_validation(self, func):
         """Decorator for adding schema validation to as_dict method."""
 

--- a/entity_management/util.py
+++ b/entity_management/util.py
@@ -2,13 +2,18 @@
 
 """Utilities"""
 
+import sys
 import typing
 from functools import wraps
-from importlib import resources
 from typing import Optional
 from urllib.parse import parse_qs
 from urllib.parse import quote as parse_quote
 from urllib.parse import unquote, urlparse
+
+if sys.version_info < (3, 9):
+    import importlib_resources as resources
+else:
+    from importlib import resources
 
 import attr
 import jsonschema

--- a/entity_management/util.py
+++ b/entity_management/util.py
@@ -10,11 +10,6 @@ from urllib.parse import parse_qs
 from urllib.parse import quote as parse_quote
 from urllib.parse import unquote, urlparse
 
-if sys.version_info < (3, 9):
-    import importlib_resources as resources
-else:
-    from importlib import resources
-
 import attr
 import jsonschema
 import yaml
@@ -27,6 +22,11 @@ from entity_management.exception import (
     ResourceNotFoundError,
     SchemaValidationError,
 )
+
+if sys.version_info < (3, 9):
+    import importlib_resources as resources
+else:
+    from importlib import resources
 
 # copied from attrs, their standard way to make validators
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dependencies = [
   "pyjwt",
   "python-keycloak",
   "click",
-  "jsonschema"
+  "jsonschema",
+  "importlib-resources; python_version <= '3.8'",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "pyjwt",
   "python-keycloak",
   "click",
+  "jsonschema"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "python-keycloak",
   "click",
   "jsonschema",
+  "pyyaml",
   "importlib-resources; python_version <= '3.8'",
 ]
 dynamic = ["version"]

--- a/tests/data/brain_region_selector_config_distribution.json
+++ b/tests/data/brain_region_selector_config_distribution.json
@@ -1,0 +1,44 @@
+{
+  "selection": [
+    {
+      "@id": "http://api.brain-map.org/api/v2/data/Structure/593",
+      "notation": "VISp1",
+      "label": "Primary visual area, layer 1"
+    },
+    {
+      "@id": "http://api.brain-map.org/api/v2/data/Structure/614454330",
+      "notation": "VISp2",
+      "label": "Primary visual area, layer 2"
+    },
+    {
+      "@id": "http://api.brain-map.org/api/v2/data/Structure/821",
+      "notation": "VISp2/3",
+      "label": "Primary visual area, layer 2/3"
+    },
+    {
+      "@id": "http://api.brain-map.org/api/v2/data/Structure/614454331",
+      "notation": "VISp3",
+      "label": "Primary visual area, layer 3"
+    },
+    {
+      "@id": "http://api.brain-map.org/api/v2/data/Structure/721",
+      "notation": "VISp4",
+      "label": "Primary visual area, layer 4"
+    },
+    {
+      "@id": "http://api.brain-map.org/api/v2/data/Structure/778",
+      "notation": "VISp5",
+      "label": "Primary visual area, layer 5"
+    },
+    {
+      "@id": "http://api.brain-map.org/api/v2/data/Structure/33",
+      "notation": "VISp6a",
+      "label": "Primary visual area, layer 6a"
+    },
+    {
+      "@id": "http://api.brain-map.org/api/v2/data/Structure/305",
+      "notation": "VISp6b",
+      "label": "Primary visual area, layer 6b"
+    }
+  ]
+}

--- a/tests/data/cell_composition_config_distribution.json
+++ b/tests/data/cell_composition_config_distribution.json
@@ -1,0 +1,44 @@
+{
+  "http://api.brain-map.org/api/v2/data/Structure/997": {
+    "variantDefinition": {
+      "algorithm": "cell_composition_manipulation",
+      "version": "v3"
+    },
+    "inputs": [
+      {
+        "name": "base_cell_composition_id",
+        "type": "Dataset",
+        "id": "https://bbp.epfl.ch/neurosciencegraph/data/cellcompositions/54818e46-cf8c-4bd6-9b68-34dffbc8a68c?tag=v1.1.0"
+      }
+    ],
+    "configuration": {
+      "version": 1,
+      "unitCode": {
+        "density": "mm^-3"
+      },
+      "overrides": {
+        "http://api.brain-map.org/api/v2/data/Structure/23": {
+          "label": "Anterior amygdalar area",
+          "about": "BrainRegion",
+          "hasPart": {
+            "https://bbp.epfl.ch/ontologies/core/bmo/GenericExcitatoryNeuronMType": {
+              "label": "GEN_mtype",
+              "about": "MType",
+              "hasPart": {
+                "https://bbp.epfl.ch/ontologies/core/bmo/GenericExcitatoryNeuronEType": {
+                  "label": "GEN_etype",
+                  "about": "EType",
+                  "composition": {
+                    "neuron": {
+                      "density": 1200
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/data/cell_position_config_distribution.json
+++ b/tests/data/cell_position_config_distribution.json
@@ -1,0 +1,21 @@
+{
+  "http://api.brain-map.org/api/v2/data/Structure/997": {
+    "variantDefinition": {
+      "algorithm": "neurons_cell_position",
+      "version": "v3"
+    },
+    "inputs": [],
+    "configuration": {
+      "place_cells": {
+        "soma_placement": "basic",
+        "density_factor": 1,
+        "sort_by": [
+          "region",
+          "mtype"
+        ],
+        "seed": 0,
+        "mini_frequencies": false
+      }
+    }
+  }
+}

--- a/tests/data/macro_connectome_config_distribution.json
+++ b/tests/data/macro_connectome_config_distribution.json
@@ -1,0 +1,27 @@
+{
+  "initial": {
+    "connection_strength": {
+      "id": "https://bbp.epfl.ch/neurosciencegraph/data/connectomestrength/8e285d4b-4d09-4357-98ae-9e9fc61face6",
+      "type": [
+        "Entity",
+        "Dataset",
+        "BrainConnectomeStrength"
+      ],
+      "rev": 10
+    }
+  },
+  "overrides": {
+    "connection_strength": {
+      "id": "https://bbp.epfl.ch/neurosciencegraph/data/wholebrainconnectomestrengths/9357f9b4-8e94-45cd-b701-8d18648a17a6",
+      "type": [
+        "Entity",
+        "Dataset",
+        "BrainConnectomeStrengthOverrides"
+      ],
+      "rev": 1
+    }
+  },
+  "_ui_data": {
+    "editHistory": []
+  }
+}

--- a/tests/data/me_model_config_distribution.json
+++ b/tests/data/me_model_config_distribution.json
@@ -1,0 +1,30 @@
+{
+    "variantDefinition": {
+        "neurons_me_model": {
+            "algorithm": "neurons_me_model",
+            "version": "v1"
+        }
+    },
+    "defaults": {
+        "neurons_me_model": {
+            "@id": "https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/2ec96e9f-7254-44b5-bbcb-fdea3e18f110",
+            "@type": ["PlaceholderEModelConfig", "Entity"]
+        }
+    },
+    "overrides": {
+        "neurons_me_model": {
+            "http://api.brain-map.org/api/v2/data/Structure/614454342": {
+                "http://uri.interlex.org/base/ilx_0381367": {
+                    "http://bbp.epfl.ch/neurosciencegraph/ontologies/etypes/cADpyr": {
+                        "assignmentAlgorithm": "assignOne",
+                        "emodel": {
+                            "@id": "https://bbp.epfl.ch/neurosciencegraph/data/f91eeb30-c6e7-40f8-8917-fd8007ec8917",
+                            "_rev": 2
+                        },
+                        "axonInitialSegmentAssignment": {"fixedValue": {"value": 1}}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/data/micro_connectome_config_distribution.json
+++ b/tests/data/micro_connectome_config_distribution.json
@@ -1,0 +1,132 @@
+{
+  "variants": {
+    "placeholder__erdos_renyi": {
+      "algorithm": "placeholder",
+      "version": "v3",
+      "params": {
+        "weight": {
+          "type": "float32",
+          "unitCode": "#synapses/connection",
+          "default": 0
+        },
+        "nsynconn_mean": {
+          "type": "float32",
+          "unitCode": "#synapses/connection",
+          "default": 3
+        },
+        "nsynconn_std": {
+          "type": "float32",
+          "unitCode": "#synapses/connection",
+          "default": 1.5
+        },
+        "delay_velocity": {
+          "type": "float32",
+          "unitCode": "um/ms",
+          "default": 250
+        },
+        "delay_offset": {
+          "type": "float32",
+          "unitCode": "ms",
+          "default": 0.8
+        }
+      }
+    },
+    "placeholder__distance_dependent": {
+      "algorithm": "placeholder",
+      "version": "v3",
+      "params": {
+        "weight": {
+          "type": "float32",
+          "unitCode": "#synapses/connection",
+          "default": 0
+        },
+        "exponent": {
+          "type": "float32",
+          "unitCode": "1/um",
+          "default": 0.008
+        },
+        "nsynconn_mean": {
+          "type": "float32",
+          "unitCode": "#synapses/connection",
+          "default": 3
+        },
+        "nsynconn_std": {
+          "type": "float32",
+          "unitCode": "#synapses/connection",
+          "default": 1.5
+        },
+        "delay_velocity": {
+          "type": "float32",
+          "unitCode": "um/ms",
+          "default": 250
+        },
+        "delay_offset": {
+          "type": "float32",
+          "unitCode": "ms",
+          "default": 0.8
+        }
+      }
+    }
+  },
+  "initial": {
+    "variants": {
+      "id": "https://bbp.epfl.ch/neurosciencegraph/data/a46a442c-5baa-4a5c-9907-bfb359dd9e5d",
+      "rev": 9,
+      "type": [
+        "Entity",
+        "Dataset",
+        "MicroConnectomeVariantSelection"
+      ]
+    },
+    "placeholder__erdos_renyi": {
+      "id": "https://bbp.epfl.ch/neurosciencegraph/data/microconnectomedata/009413eb-e51b-40bc-9199-8b98bfc53f87",
+      "rev": 7,
+      "type": [
+        "Entity",
+        "Dataset",
+        "MicroConnectomeData"
+      ]
+    },
+    "placeholder__distance_dependent": {
+      "id": "https://bbp.epfl.ch/neurosciencegraph/data/microconnectomedata/c7e1d215-2dad-4216-8565-6b1e4c161f46",
+      "rev": 7,
+      "type": [
+        "Entity",
+        "Dataset",
+        "MicroConnectomeData"
+      ]
+    }
+  },
+  "overrides": {
+    "variants": {
+      "id": "https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/deee5e86-1d7b-45f6-8fad-259a71c35c6a",
+      "type": [
+        "Entity",
+        "Dataset",
+        "MicroConnectomeVariantSelectionOverrides"
+      ],
+      "rev": 1
+    },
+    "placeholder__erdos_renyi": {
+      "id": "https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/36426136-201d-4dfd-93d9-b541e113a6bf",
+      "type": [
+        "Entity",
+        "Dataset",
+        "MicroConnectomeDataOverrides"
+      ],
+      "rev": 1
+    },
+    "placeholder__distance_dependent": {
+      "id": "https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/4bb03c2b-b99d-4a5d-8a8b-12e1a30619aa",
+      "type": [
+        "Entity",
+        "Dataset",
+        "MicroConnectomeDataOverrides"
+      ],
+      "rev": 1
+    }
+  },
+  "_ui_data": {
+    "editHistory": []
+  }
+}

--- a/tests/data/morphology_assignment_config_distribution.json
+++ b/tests/data/morphology_assignment_config_distribution.json
@@ -1,0 +1,50 @@
+{
+  "variantDefinition": {
+    "topological_synthesis": {
+      "algorithm": "topological_synthesis",
+      "version": "v1"
+    },
+    "placeholder_assignment": {
+      "algorithm": "placeholder_assignment",
+      "version": "v1"
+    }
+  },
+  "defaults": {
+    "topological_synthesis": {
+      "@id": "https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/5ec117b5-8ffa-4f3b-95ca-1dc8ad1b0c4d",
+      "@type": [
+        "CanonicalMorphologyModelConfig",
+        "Entity"
+      ]
+    },
+    "placeholder_assignment": {
+      "@id": "https://bbp.epfl.ch/neurosciencegraph/data/06b340d4-ac99-4459-bab4-013ef7199c36",
+      "@type": [
+        "PlaceholderMorphologyConfig",
+        "Entity"
+      ],
+      "_rev": 2
+    }
+  },
+  "configuration": {
+    "topological_synthesis": {
+      "http://api.brain-map.org/api/v2/data/Structure/632": {
+        "https://bbp.epfl.ch/ontologies/core/bmo/GenericExcitatoryNeuronMType": {
+          "@id": "https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/canonicalmorphologymodels/dfda5210-39b5-428d-ac0c-43852f99df02",
+          "overrides": {
+            "apical_dendrite": {
+              "randomness": 0.11,
+              "step_size": {
+                "norm": {
+                  "mean": 7.6,
+                  "std": 0.2
+                }
+              },
+              "targeting": 0.34
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/data/synapse_config_distribution.json
+++ b/tests/data/synapse_config_distribution.json
@@ -1,0 +1,42 @@
+{
+  "variantDefinition": {
+    "algorithm": "synapses",
+    "version": "v2"
+  },
+  "defaults": {
+    "synapse_properties": {
+      "id": "https://bbp.epfl.ch/neurosciencegraph/data/synapticassignment/d57536aa-d576-4b3b-a89b-b7888f24eb21",
+      "type": [
+        "Dataset",
+        "SynapticParameterAssignment"
+      ],
+      "rev": 9
+    },
+    "synapses_classification": {
+      "id": "https://bbp.epfl.ch/neurosciencegraph/data/synapticparameters/cf25c2bf-e6e4-4367-acd8-94004bfcfe49",
+      "type": [
+        "Dataset",
+        "SynapticParameter"
+      ],
+      "rev": 6
+    }
+  },
+  "configuration": {
+    "synapse_properties": {
+      "id": "https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/839a8b83-1620-4fe7-8f58-658ded0ea1e8",
+      "type": [
+        "Dataset",
+        "SynapticParameterAssignment"
+      ],
+      "rev": 1
+    },
+    "synapses_classification": {
+      "id": "https://bbp.epfl.ch/data/bbp/mmb-point-neuron-framework-model/d133e408-bd00-41ca-9334-e5fab779ad99",
+      "type": [
+        "Dataset",
+        "SynapticParameter"
+      ],
+      "rev": 3
+    }
+  }
+}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,15 +8,18 @@ from entity_management.util import validate_schema
 DATA_DIR = Path(__file__).parent / "data"
 
 
-@pytest.mark.parametrize("schema_name", [
-    "cell_composition_config_distribution",
-    "cell_position_config_distribution",
-    "morphology_assignment_config_distribution",
-    "me_model_config_distribution",
-    "macro_connectome_config_distribution",
-    "micro_connectome_cofnig_distribution",
-    "synapse_config_distribution",
-])
+@pytest.mark.parametrize(
+    "schema_name",
+    [
+        "cell_composition_config_distribution",
+        "cell_position_config_distribution",
+        "morphology_assignment_config_distribution",
+        "me_model_config_distribution",
+        "macro_connectome_config_distribution",
+        "micro_connectome_config_distribution",
+        "synapse_config_distribution",
+    ],
+)
 def test_config_distribution_schema(schema_name):
     schema = f"{schema_name}.yml"
     example = DATA_DIR / f"{schema_name}.json"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+import pytest
+from entity_management import config as test_module
+from entity_management.util import validate_schema
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+@pytest.mark.parametrize("schema_name", [
+    "cell_composition_config_distribution",
+    "cell_position_config_distribution",
+    "morphology_assignment_config_distribution",
+    "me_model_config_distribution",
+    "macro_connectome_config_distribution",
+    "micro_connectome_cofnig_distribution",
+    "synapse_config_distribution",
+])
+def test_config_distribution_schema(schema_name):
+    schema = f"{schema_name}.yml"
+    example = DATA_DIR / f"{schema_name}.json"
+    data = json.loads(example.read_bytes())
+    validate_schema(data=data, schema_name=schema)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ DATA_DIR = Path(__file__).parent / "data"
 @pytest.mark.parametrize(
     "schema_name",
     [
+        "brain_region_selector_config_distribution",
         "cell_composition_config_distribution",
         "cell_position_config_distribution",
         "morphology_assignment_config_distribution",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -235,3 +235,15 @@ def test_lazy_schema_validator(tmp_path):
     # should not pass because the distribution object has no 'as_dict'
     with pytest.raises(RuntimeError, match="Expected instance with as_dict method. Got Wrong()"):
         C(distribution=Wrong()).distribution.as_dict()
+
+    with pytest.raises(FileNotFoundError, match="Schema fake.yml not found."):
+
+        @attributes(
+            {
+                "distribution": AttrOf(
+                    Wrong, validators=[test_module.LazySchemaValidator(schema="fake.yml")]
+                )
+            }
+        )
+        class D(Entity):
+            pass

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,7 @@ from unittest.mock import patch, Mock
 import attr
 
 import sys
-import json
+import yaml
 import pytest
 from typing import Union, List
 from entity_management import exception
@@ -171,7 +171,7 @@ def test_lazy_schema_validator(tmp_path):
     }
 
     schema1_file = tmp_path / "test_schema1.yml"
-    schema1_file.write_text(json.dumps(schema1))
+    schema1_file.write_text(yaml.dump(schema1))
 
     schema2 = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -180,7 +180,7 @@ def test_lazy_schema_validator(tmp_path):
     }
 
     schema2_file = tmp_path / "test_schema2.yml"
-    schema2_file.write_text(json.dumps(schema2))
+    schema2_file.write_text(yaml.dump(schema2))
 
     data = {
         "foo": "foo",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,14 +1,15 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 import attr
 
 import sys
+import json
 import pytest
 from typing import Union, List
 from entity_management import exception
 from entity_management import util as test_module
 from entity_management.core import Entity, attributes
 from entity_management.util import AttrOf
-from entity_management.base import BlankNode
+from entity_management.base import BlankNode, Frozen
 from entity_management.typing import MaybeList
 
 
@@ -159,3 +160,78 @@ def test_url_params():
     res_url, res_params = test_module.split_url_params(url)
     assert res_url == "https://foo/bar"
     assert res_params == {"tag": ["v1.1"]}
+
+
+def test_lazy_schema_validator(tmp_path):
+
+    schema1 = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "my-schema1",
+        "properties": {"foo": {"type": "string"}, "bar": {"type": "integer"}},
+    }
+
+    schema1_file = tmp_path / "test_schema1.yml"
+    schema1_file.write_text(json.dumps(schema1))
+
+    schema2 = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "my-schema2",
+        "properties": {"foo": {"type": "string"}, "bar": {"type": "string"}},
+    }
+
+    schema2_file = tmp_path / "test_schema2.yml"
+    schema2_file.write_text(json.dumps(schema2))
+
+    data = {
+        "foo": "foo",
+        "bar": 2,
+    }
+
+    class MockDataDownload(Frozen):
+        def as_dict(self):
+            return data
+
+    class Wrong(Frozen):
+        pass
+
+    @attributes(
+        {
+            "distribution": AttrOf(
+                MockDataDownload, validators=[test_module.LazySchemaValidator(schema=schema1_file)]
+            )
+        }
+    )
+    class A(Entity):
+        pass
+
+    # should pass schema validation
+    res = A(distribution=MockDataDownload()).distribution.as_dict()
+    assert res == data
+
+    @attributes(
+        {
+            "distribution": AttrOf(
+                MockDataDownload, validators=[test_module.LazySchemaValidator(schema=schema2_file)]
+            )
+        }
+    )
+    class B(Entity):
+        pass
+
+    # should not pass because 2 is not a string
+    with pytest.raises(test_module.SchemaValidationError):
+        B(distribution=MockDataDownload()).distribution.as_dict()
+
+    @attributes(
+        {
+            "distribution": AttrOf(
+                Wrong, validators=[test_module.LazySchemaValidator(schema=schema1_file)]
+            )
+        }
+    )
+    class C(Entity):
+        pass
+
+    # should not pass because the distribution object has no 'as_dict'
+    with pytest.raises(RuntimeError, match="Expected instance with as_dict method. Got Wrong()"):
+        C(distribution=Wrong()).distribution.as_dict()


### PR DESCRIPTION
Introduce a distribution schema validator that can be added in the AttrOf validators as follows:

```python
@attributes({
    "distribution": AttrOf(
        DataDownload,
        validators=[LazySchemaValidator(schema="my_schema.yml")]
   )})
class A(Entity):
    pass
```

Which decorates the `as_dict` method of an object by validating its contents against a schema stored in `entity_management/schemas/` when `as_dict` method is called.

Added schemas for the ModelBuildingConfig sub-config distributions.